### PR TITLE
[WIP] static array tests

### DIFF
--- a/test/static_array_tests.jl
+++ b/test/static_array_tests.jl
@@ -1,5 +1,5 @@
 using StaticArrays, StochasticDiffEq
-
+using Test
 f(du,u,p,t) = (du .= u)
 
 u0 = zeros(MVector{2,Float64}, 2) .+ 1
@@ -14,14 +14,15 @@ ode = SDEProblem(f, f, u0, (0.,1.))
 @test_broken sol = solve(ode, EM(), dt=1.e-2)
 @test_broken sol = solve(ode, SRIW1(), dt=1.e-2)
 
-
 u0 = ones(MVector{2,Float64})
 ode = SDEProblem(f, f, u0, (0.,1.))
 sol = solve(ode, EM(), dt=1.e-2)
 sol = solve(ode, SRIW1())
+sol = solve(ode, DRI1(), dt=1.e-2)
 
 u0 = ones(SVector{2,Float64})
 f(u,p,t) = u
 prob = SDEProblem(f, f, u0, (0.,1.))
-sol = solve(ode, EM(), dt=1.e-2)
-sol = solve(ode, SRIW1())
+@test_broken sol = solve(prob, EM(), dt=1.e-2)
+@test_broken sol = solve(prob, SRIW1())
+@test_broken sol = solve(prob, DRI1(), dt=1.e-2)


### PR DESCRIPTION
I think that there is a problem with the static array tests.  "ode" instead of "prob" was used, so SVector didn't actually work yet.

Should this be fixed by modifying `calculate_step!(W::NoiseProcess,dt)` in` DiffEqNoiseProcess`

Here is the stack trace:

```
sol = solve(prob, DRI1(), dt=1.e-2)
ERROR: setindex!(::SArray{Tuple{2},Float64,1,2}, value, ::Int) is not defined.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] setindex!(::SArray{Tuple{2},Float64,1,2}, ::Float64, ::Int64) at /Users/frank/.julia/packages/StaticArrays/mlIi1/src/indexing.jl:3
 [3] macro expansion at ./broadcast.jl:910 [inlined]
 [4] macro expansion at ./simdloop.jl:77 [inlined]
 [5] copyto! at ./broadcast.jl:909 [inlined]
 [6] copyto! at ./broadcast.jl:875 [inlined]
 [7] materialize! at ./broadcast.jl:823 [inlined]
 [8] wiener_randn! at /Users/frank/.julia/packages/DiffEqNoiseProcess/GWKRQ/src/wiener.jl:12 [inlined]
 [9] INPLACE_WHITE_NOISE_DIST(::SArray{Tuple{2},Float64,1,2}, ::DiffEqNoiseProcess.NoiseProcess{Float64,2,Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2},Array{SArray{Tuple{2},Float64,1,2},1},typeof(DiffEqNoiseProcess.INPLACE_WHITE_NOISE_DIST),typeof(DiffEqNoiseProcess.INPLACE_WHITE_NOISE_BRIDGE),true,DataStructures.Stack{Tuple{Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2}}},ResettableStacks.ResettableStack{Tuple{Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2}},true},DiffEqNoiseProcess.RSWM{:RSwM1,Float64},RandomNumbers.Xorshifts.Xoroshiro128Plus}, ::Float64, ::RandomNumbers.Xorshifts.Xoroshiro128Plus) at /Users/frank/.julia/packages/DiffEqNoiseProcess/GWKRQ/src/wiener.jl:41
 [10] calculate_step! at /Users/frank/.julia/packages/DiffEqNoiseProcess/GWKRQ/src/noise_interfaces/noise_process_interface.jl:177 [inlined]
 [11] setup_next_step!(::DiffEqNoiseProcess.NoiseProcess{Float64,2,Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2},Array{SArray{Tuple{2},Float64,1,2},1},typeof(DiffEqNoiseProcess.INPLACE_WHITE_NOISE_DIST),typeof(DiffEqNoiseProcess.INPLACE_WHITE_NOISE_BRIDGE),true,DataStructures.Stack{Tuple{Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2}}},ResettableStacks.ResettableStack{Tuple{Float64,SArray{Tuple{2},Float64,1,2},SArray{Tuple{2},Float64,1,2}},true},DiffEqNoiseProcess.RSWM{:RSwM1,Float64},RandomNumbers.Xorshifts.Xoroshiro128Plus}) at /Users/frank/.julia/packages/DiffEqNoiseProcess/GWKRQ/src/noise_interfaces/noise_process_interface.jl:51
 [12] __init(::SDEProblem{SArray{Tuple{2},Float64,1,2},Tuple{Float64,Float64},true,DiffEqBase.NullParameters,Nothing,SDEFunction{true,typeof(f),typeof(f),LinearAlgebra.UniformScaling{Bool},Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},typeof(f),Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},Nothing}, ::DRI1, ::Array{Any,1}, ::Array{Any,1}, ::Type{T} where T, ::Type{Val{true}}; saveat::Array{Float64,1}, tstops::Array{Float64,1}, d_discontinuities::Array{Float64,1}, save_idxs::Nothing, save_everystep::Bool, save_noise::Bool, save_on::Bool, save_start::Bool, save_end::Bool, callback::Nothing, dense::Bool, calck::Bool, dt::Float64, adaptive::Bool, gamma::Rational{Int64}, abstol::Nothing, reltol::Nothing, qmax::Rational{Int64}, qmin::Rational{Int64}, qoldinit::Rational{Int64}, fullnormalize::Bool, failfactor::Int64, beta2::Rational{Int64}, beta1::Rational{Int64}, delta::Rational{Int64}, maxiters::Int64, dtmax::Float64, dtmin::Float64, internalnorm::typeof(DiffEqBase.ODE_DEFAULT_NORM), isoutofdomain::typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN), unstable_check::typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK), verbose::Bool, force_dtmin::Bool, timeseries_errors::Bool, dense_errors::Bool, advance_to_tstop::Bool, stop_at_next_tstop::Bool, initialize_save::Bool, progress::Bool, progress_steps::Int64, progress_name::String, progress_message::typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE), userdata::Nothing, initialize_integrator::Bool, seed::UInt64, alias_u0::Bool, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/frank/.julia/dev/StochasticDiffEq/src/solve.jl:389
 [13] __solve(::SDEProblem{SArray{Tuple{2},Float64,1,2},Tuple{Float64,Float64},true,DiffEqBase.NullParameters,Nothing,SDEFunction{true,typeof(f),typeof(f),LinearAlgebra.UniformScaling{Bool},Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},typeof(f),Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},Nothing}, ::DRI1, ::Array{Any,1}, ::Array{Any,1}, ::Nothing, ::Type{Val{true}}; kwargs::Base.Iterators.Pairs{Symbol,Float64,Tuple{Symbol},NamedTuple{(:dt,),Tuple{Float64}}}) at /Users/frank/.julia/dev/StochasticDiffEq/src/solve.jl:6
 [14] (::DiffEqBase.var"#442#443"{SDEProblem{SArray{Tuple{2},Float64,1,2},Tuple{Float64,Float64},true,DiffEqBase.NullParameters,Nothing,SDEFunction{true,typeof(f),typeof(f),LinearAlgebra.UniformScaling{Bool},Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},typeof(f),Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},Nothing},Tuple{DRI1}})() at /Users/frank/.julia/dev/DiffEqBase/src/solve.jl:49
 [15] maybe_with_logger at /Users/frank/.julia/dev/DiffEqBase/src/utils.jl:259 [inlined]
 [16] solve_call(::SDEProblem{SArray{Tuple{2},Float64,1,2},Tuple{Float64,Float64},true,DiffEqBase.NullParameters,Nothing,SDEFunction{true,typeof(f),typeof(f),LinearAlgebra.UniformScaling{Bool},Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},typeof(f),Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},Nothing}, ::DRI1; merge_callbacks::Bool, kwargs::Base.Iterators.Pairs{Symbol,Float64,Tuple{Symbol},NamedTuple{(:dt,),Tuple{Float64}}}) at /Users/frank/.julia/dev/DiffEqBase/src/solve.jl:48
 [17] #solve#444 at /Users/frank/.julia/dev/DiffEqBase/src/solve.jl:66 [inlined]
 [18] top-level scope at none:0
 
```