### PR TITLE
tstop checks for reverse time propagation

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -69,9 +69,10 @@ jac_iter(integrator::SDEIntegrator) = jac_iter(integrator.cache)
 jac_iter(integrator::StochasticCompositeCache) = Iterators.flatten(jac_iter(c) for c in integrator.caches)
 
 @inline function add_tstop!(integrator::SDEIntegrator,t)
-  t < integrator.t && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
+  integrator.tdir * (t - integrator.t) < 0 && error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
   push!(integrator.opts.tstops, integrator.tdir * t)
 end
+
 
 function DiffEqBase.add_saveat!(integrator::SDEIntegrator,t)
   integrator.tdir * (t - integrator.t) < 0 && error("Tried to add a saveat that is behind the current time. This is strictly forbidden")

--- a/test/tstops_tests.jl
+++ b/test/tstops_tests.jl
@@ -21,3 +21,19 @@ sol = solve(prob,EM(),tstops = [0.33,0.80,1.0])
 sol = solve(prob,SRIW1(),tstops = [0.33])
 
 @test 0.33 ∈ sol.t
+
+
+# check reverse time and negative start times
+for (i, tdir) in enumerate([-1.; 1.])
+  @info i
+  prob2 = remake(prob_sde_linear, tspan=(tdir*1.0, 0.0))
+  integrator = init(prob2,SRIW1())
+  tstops = tdir .* [0,0.33,0.80,1]
+  for tstop in tstops
+    add_tstop!(integrator, tstop)
+  end
+  solve!(integrator)
+  for tstop in tstops
+    @test tstop ∈ integrator.sol.t
+  end
+end


### PR DESCRIPTION
Fixes an error which I got for SDE adjoints where propagation from (tend, tstart) with tend>tstart is used, see https://github.com/SciML/DiffEqSensitivity.jl/pull/242.