### PR TITLE
Seeding fix

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -76,7 +76,7 @@ function DiffEqBase.__init(
   if typeof(_prob) <: JumpProblem
     if alias_jumps
       _prob = DiffEqJump.resetted_jump_problem(_prob, _seed)
-    else
+    elseif _seed !== 0  
       DiffEqJump.reset_jump_problem!(_prob, _seed)
     end
   end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -75,9 +75,9 @@ function DiffEqBase.__init(
 
   if typeof(_prob) <: JumpProblem
     if alias_jumps
-      _prob = DiffEqJump.resetted_jump_problem(_prob,seed)
-    elseif seed !== 0
-      DiffEqJump.reset_jump_problem!(_prob,seed)
+      _prob = DiffEqJump.resetted_jump_problem(_prob, _seed)
+    else
+      DiffEqJump.reset_jump_problem!(_prob, _seed)
     end
   end
 


### PR DESCRIPTION
@ChrisRackauckas 

Just to double check, this bit of logic is the exact opposite of what is in the DiffEqJump `__init` call at 

https://github.com/SciML/DiffEqJump.jl/blob/f03cc8976d1300bcd5ec78d73d776e69c21f777c/src/solve.jl#L17

is this correct?