### PR TITLE
refine DRI1 and RI1 tests

### DIFF
--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -253,7 +253,7 @@ end
 
 
 function alg_cache(alg::RI1,prob,u,ΔW,ΔZ,p,rate_prototype,
-                   noise_rate_prototype,uEltypeNoUnits,
+                   noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,
                    uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
   if typeof(ΔW) <: Union{SArray,Number}
     _dW = copy(ΔW)

--- a/test/weak_convergence/srk_weak_final.jl
+++ b/test/weak_convergence/srk_weak_final.jl
@@ -1,6 +1,6 @@
 """
  Tests for https://arxiv.org/abs/1303.5103 with test problems as in the paper.
- DRI1 (and RI1)
+ DRI1 + RI1
 """
 
 
@@ -9,39 +9,51 @@ import LinearAlgebra # for the normn
 using StochasticDiffEq
 using Test
 using Random
-Random.seed!(100)
 #using DiffEqGPU
+
 #using Plots
+
+function generate_weak_solutions(prob, alg, dts, numtraj; ensemblealg=EnsembleThreads())
+  sols = []
+  for i in 1:length(dts)
+    sol = solve(prob,alg;ensemblealg=ensemblealg,dt=dts[i],save_start=false,save_everystep=false,weak_timeseries_errors=false,weak_dense_errors=false,trajectories=Int(numtraj))
+    println(i)
+    push!(sols,sol)
+  end
+  return sols
+end
+
+
+function prob_func(prob, i, repeat)
+    remake(prob,seed=seeds[i])
+end
 
 """
  Test Scalar SDEs (oop)
 """
 
-numtraj = 1e4 # in the paper they use 1e9
+numtraj = Int(2e5) # in the paper they use 1e9
 u₀ = 0.0
 f(u,p,t) = 1//2*u+sqrt(u^2+1)
 g(u,p,t) = sqrt(u^2+1)
 dts = 1 .//2 .^(4:-1:1)
-tspan = (0.0,1.0) # 2.0 in paper
-prob = SDEProblem(f,g,u₀,tspan)
+tspan = (0.0,2.0) # 2.0 in paper
+
 
 h1(z) = z^3-6*z^2+8*z
-
 #analytical_sol(t) = E(f(X(t))) = E(h1(arsinh(X(t))) = t^3-3*t^2+2*t
 #analytical_sol(2) = 0 and analytical_sol(1)=0
+
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+prob = SDEProblem(f,g,u₀,tspan)
 ensemble_prob = EnsembleProblem(prob;
-        output_func = (sol,i) -> (h1(asinh(sol[end])),false)
+        output_func = (sol,i) -> (h1(asinh(sol[end])),false),
+        prob_func = prob_func
         )
-N = length(dts)
-_solutions = @time [solve(ensemble_prob,
-        DRI1();
-        #ensemblealg = EnsembleGPUArray(); # EnsembleGPUArray or EnsembleDistributed()
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+_solutions = @time generate_weak_solutions(ensemble_prob, DRI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
@@ -51,24 +63,17 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 #savefig(convergence_plot, "DRI1-CPU-final-"*string(numtraj)*".pdf")
 println("DRI1:", m)
 
+numtraj = Int(5e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
 
-
-_solutions = @time [solve(ensemble_prob,
-        RI1();
-        #ensemblealg = EnsembleGPUArray(); # EnsembleGPUArray or EnsembleDistributed()
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+_solutions = @time generate_weak_solutions(ensemble_prob, RI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.3
 
-# convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-# savefig(convergence_plot, "RI1-CPU-final-"*string(numtraj)*".pdf")
 println("RI1:", m)
 
 
@@ -76,45 +81,42 @@ println("RI1:", m)
  Test Scalar SDEs (iip)
 """
 
-numtraj = 1e4
+
 u₀ = [0.0]
 f1!(du,u,p,t) = @.(du = 1//2*u+sqrt(u^2 +1))
 g1!(du,u,p,t) = @.(du = sqrt(u^2 +1))
 dts = 1 .//2 .^(4:-1:1)
-tspan = (0.0,1.0)
-prob = SDEProblem(f1!,g1!,u₀,tspan)
+tspan = (0.0,2.0)
 
 h1(z) = z^3-6*z^2+8*z
 
+prob = SDEProblem(f1!,g1!,u₀,tspan)
 ensemble_prob = EnsembleProblem(prob;
-        output_func = (sol,i) -> (h1(asinh(sol[end][1])),false)
+        output_func = (sol,i) -> (h1(asinh(sol[end][1])),false),
+        prob_func = prob_func
         )
-N = length(dts)
-_solutions = @time [solve(ensemble_prob,
-        DRI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+
+
+numtraj = Int(2e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+
+_solutions = @time generate_weak_solutions(ensemble_prob, DRI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.3
 
-# convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-# savefig(convergence_plot, "Scalar-DRI1-CPU-final-"*string(numtraj)*".pdf")
 println("DRI1:", m)
 
-_solutions = @time [solve(ensemble_prob,
-        RI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+numtraj = Int(5e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, RI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
@@ -126,7 +128,7 @@ println("RI1:", m)
  Test non-commutative noise SDEs (iip)
 """
 
-numtraj = 1e4
+
 u₀ = [1.0,1.0]
 function f2!(du,u,p,t)
   du[1] = -273//512*u[1]
@@ -140,41 +142,36 @@ function g2!(du,u,p,t)
 end
 dts = 1 .//2 .^(3:-1:0)
 tspan = (0.0,3.0)
-prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
 
 h2(z) = z^2 # but apply it only to u[1]
 
+prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
 ensemble_prob = EnsembleProblem(prob;
-        output_func = (sol,i) -> (h2(sol[end][1]),false)
+        output_func = (sol,i) -> (h2(sol[end][1]),false),
+        prob_func = prob_func
         )
-N = length(dts)
-_solutions = @time [solve(ensemble_prob,
-        DRI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
 
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-exp(-10.0)) for sol in _solutions]
+numtraj = Int(1e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+
+_solutions = @time generate_weak_solutions(ensemble_prob, DRI1(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-exp(-3.0)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.3
 
-# convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-# savefig(convergence_plot, "ND-DRI1-CPU-final-"*string(numtraj)*".pdf")
 println("DRI1:", m)
 
-_solutions = @time [solve(ensemble_prob,
-        RI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+numtraj = Int(2e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+_solutions = @time generate_weak_solutions(ensemble_prob, RI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-exp(-10.0)) for sol in _solutions]
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-exp(-3.0)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.3
 
@@ -184,7 +181,6 @@ println("RI1:", m)
  Test Diagonal noise SDEs (iip), SIAM Journal on Numerical Analysis, 47 (2009), pp. 1713–1738
 """
 
-numtraj = 5e5
 u₀ = [0.1,0.1]
 function f3!(du,u,p,t)
   du[1] = 3//2*u[1]
@@ -196,22 +192,21 @@ function g3!(du,u,p,t)
 end
 dts = 1 .//2 .^(3:-1:0)
 tspan = (0.0,1.0)
-prob = SDEProblem(f3!,g3!,u₀,tspan)
 
 h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t) if h3(z) = z^2 )
 
+prob = SDEProblem(f3!,g3!,u₀,tspan)
 ensemble_prob = EnsembleProblem(prob;
-        output_func = (sol,i) -> (h3(sol[end][1]),false)
+        output_func = (sol,i) -> (h3(sol[end][1]),false),
+        prob_func = prob_func
         )
-N = length(dts)
-_solutions = @time [solve(ensemble_prob,
-        DRI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+
+numtraj = Int(5e4)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, DRI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
@@ -219,20 +214,11 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("DRI1:", m)
 
-#convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-#savefig(convergence_plot, "RI1-CPU-final-"*string(numtraj)*".pdf")
-#println(m)
 
-_solutions = @time [solve(ensemble_prob,
-        RI1();
-        dt=dts[i],
-        save_start=false,
-        save_everystep=false,
-        weak_timeseries_errors=false,
-        weak_dense_errors=false,
-        trajectories=numtraj) for i in 1:N]
+_solutions = @time generate_weak_solutions(ensemble_prob, RI1(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.5
+
 println("RI1:", m)


### PR DESCRIPTION
I adjusted the number of trajectories, included a `prob_func` for better reproducibility, and replaced the list comprehensions by a loop.