### PR TITLE
NON

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -129,7 +129,8 @@ module StochasticDiffEq
          AutoSOSRI2, AutoSOSRA2,
          DRI1, DRI1NM, RI1, RI3, RI5, RI6, RDI1WM, RDI2WM, RDI3WM, RDI4WM,
          RS1, RS2,
-         PL1WM, PL1WMA
+         PL1WM, PL1WMA,
+         NON
 
   export EulerHeun, LambaEulerHeun
 
@@ -154,9 +155,11 @@ module StochasticDiffEq
 
   #Misc Tools
   export checkSRIOrder, checkSRAOrder,  checkRIOrder, checkRSOrder,
+         checkNONOrder,
          constructSRIW1, constructSRA1,
          constructDRI1, constructRI1, constructRI3, constructRI5, constructRI6,
          constructRDI1WM, constructRDI2WM, constructRDI3WM, constructRDI4WM,
-         constructRS1, constructRS2
+         constructRS1, constructRS2,
+         constructNON
 
 end # module

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -82,6 +82,8 @@ alg_order(alg::RS2) = 1//1
 alg_order(alg::PL1WM) = 1//1
 alg_order(alg::PL1WMA) = 1//1
 
+alg_order(alg::NON) = 1//1
+
 alg_order(alg::TauLeaping) = 1//1
 alg_order(alg::CaoTauLeaping) = 1//1
 
@@ -107,6 +109,8 @@ alg_interpretation(alg::ImplicitRKMil{CS,AD,F,S,N,T2,Controller,interpretation})
 
 alg_interpretation(alg::RS1) = :Stratonovich
 alg_interpretation(alg::RS2) = :Stratonovich
+
+alg_interpretation(alg::NON) = :Stratonovich
 
 alg_compatible(prob,alg::Union{StochasticDiffEqAlgorithm,StochasticDiffEqRODEAlgorithm}) = true
 alg_compatible(prob,alg::StochasticDiffEqAlgorithm) = false
@@ -143,6 +147,7 @@ alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::RS1) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::RS2) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WM) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WMA) = true
+alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::NON) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SKenCarp) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::EM) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::LambaEM) = true
@@ -206,6 +211,7 @@ alg_needs_extra_process(alg::RDI4WM) = true
 alg_needs_extra_process(alg::RS1) = true
 alg_needs_extra_process(alg::RS2) = true
 alg_needs_extra_process(alg::PL1WM) = true
+alg_needs_extra_process(alg::NON) = true
 
 OrdinaryDiffEq.alg_autodiff(alg::StochasticDiffEqNewtonAlgorithm{CS,AD,Controller}) where {CS,AD,Controller} = AD
 OrdinaryDiffEq.alg_autodiff(alg::StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,Controller}) where {CS,AD,Controller} = AD

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -315,6 +315,8 @@ Springer. Berlin Heidelberg (2011)
 """
 struct PL1WMA <: StochasticDiffEqAlgorithm end
 
+struct NON <: StochasticDiffEqAlgorithm end
+
 ################################################################################
 
 # IIF

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -315,6 +315,12 @@ Springer. Berlin Heidelberg (2011)
 """
 struct PL1WMA <: StochasticDiffEqAlgorithm end
 
+"""
+Komori, Y., Weak second-order stochastic Runge–Kutta methods for non-commutative
+stochastic differential equations, Journal of Computational and Applied
+Mathematics 206, pp. 158 – 173 (2007)
+DOI:10.1016/j.cam.2006.06.006
+"""
 struct NON <: StochasticDiffEqAlgorithm end
 
 ################################################################################

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1531,3 +1531,113 @@ function alg_cache(alg::PL1WMA,prob,u,ΔW,ΔZ,p,rate_prototype,
 
   PL1WMACache(u,uprev,_dW,chi1,tab,g1,k1,k2,Y,tmp1)
 end
+
+
+
+#NON
+struct NONConstantCache{T} <: StochasticDiffEqConstantCache
+  c01::T
+  c02::T
+  c03::T
+  c04::T
+
+  cj1::T
+  cj2::T
+  cj3::T
+  cj4::T
+
+  cjl2::T
+  cjl3::T
+
+  clj2::T
+  clj3::T
+
+  a0021::T
+  a0032::T
+  a0043::T
+
+  aj021::T
+  aj041::T
+
+  a0j21::T
+  a0j31::T
+  a0j32::T
+  a0j41::T
+
+  ajj21::T
+  ajj31::T
+  ajj32::T
+  ajj41::T
+  ajj42::T
+  ajj43::T
+
+  ajl31::T
+  ajl32::T
+  ajl41::T
+  ajl42::T
+
+  ajljj31::T
+
+  aljjl21::T
+  ajljj31::T
+
+  #quantile(Normal(),1/6)
+  NORMAL_ONESIX_QUANTILE::T
+end
+
+
+function NONConstantCache(T::Type)
+  c01 = convert(T, 1//6)
+  c02 = convert(T, 1//3)
+  c03 = convert(T, 1//3)
+  c04 = convert(T, 1//6)
+
+  cj1 = convert(T, 1//8)
+  cj2 = convert(T, 3//8)
+  cj3 = convert(T, 3//8)
+  cj4 = convert(T, 1//8)
+
+  cjl2 = convert(T, 1//2)
+  cjl3 = convert(T, -1//2)
+
+  clj2 = convert(T, -1//2)
+  clj3 = convert(T, 1//2)
+
+  a0021 = convert(T, 1//2)
+  a0032 = convert(T, 1//2)
+  a0043 = convert(T, 1)
+
+  aj021 = convert(T, 2)
+  aj041 = convert(T, -2)
+
+  a0j21 = convert(T, 1)
+  a0j31 = convert(T, -9//8)
+  a0j32 = convert(T, 9//8)
+  a0j41 = convert(T, 1)
+
+  ajj21 = convert(T, 2//3)
+  ajj31 = convert(T, 1//12)
+  ajj32 = convert(T, 1//4)
+  ajj41 = convert(T, -5//4)
+  ajj42 = convert(T, 1//4)
+  ajj43 = convert(T, 2)
+
+  ajl31 = convert(T, 1//4)
+  ajl32 = convert(T, 3//4)
+  ajl41 = convert(T, 1//4)
+  ajl42 = convert(T, 3//4)
+
+  ajljj31 = convert(T, 1)
+
+  aljjl21 = convert(T, -1//2)
+  ajljj31 = convert(T, 1//2)
+
+  NORMAL_ONESIX_QUANTILE = convert(T,-0.9674215661017014)
+
+  NONConstantCache(c01,c02,c03,c04,cj1,cj2,cj3,cj4,cjl2,cjl3,clj2,clj3,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,ajljj31,aljjl21,ajljj31,NORMAL_ONESIX_QUANTILE)
+end
+
+
+function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
+  NONConstantCache(real(uBottomEltypeNoUnits))
+end

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1657,25 +1657,21 @@ end
 
   tab::tabType
 
-  g1::rateNoiseType
-  g2::Vector{rateNoiseType}
-  g3::Vector{rateNoiseType}
-  g4::Vector{rateNoiseType}
+  gtmp::rateNoiseType
+  ktmp::rateType
 
-  k1::rateType
-  k2::rateType
-  k3::rateType
-  k4::rateType
-
+  Y100::uType
   Y200::uType
   Y300::uType
   Y400::uType
-  Y2jj::Vector{uType}
-  Y3jj::Vector{uType}
-  Y4jj::Vector{uType}
+  Y1jj::rateNoiseType
+  Y2jj::rateNoiseType
+  Y3jj::rateNoiseType
+  Y4jj::rateNoiseType
 
   tmp1::possibleRateType
-  tmpg::rateNoiseType
+  tmpu::uType
+  #tmpg::rateNoiseType
 
 end
 
@@ -1695,28 +1691,24 @@ function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,
   m = length(ΔW)
   Ihat2 = zeros(eltype(ΔW), m, m)
   tab = NONConstantCache(real(uBottomEltypeNoUnits))
-  g1 = zero(noise_rate_prototype)
-  g2 = [zero(noise_rate_prototype) for k=1:m]
-  g3 = [zero(noise_rate_prototype) for k=1:m]
-  g4 = [zero(noise_rate_prototype) for k=1:m]
-  k1 = zero(rate_prototype); k2 = zero(rate_prototype); k3 = zero(rate_prototype); k4 = zero(rate_prototype)
 
+  gtmp = zero(noise_rate_prototype)
+  ktmp = zero(rate_prototype)
+
+  Y100 = zero(u)
   Y200 = zero(u)
   Y300 = zero(u)
   Y400 = zero(u)
-  Y2jj = Vector{typeof(u)}()
-  Y3jj = Vector{typeof(u)}()
-  Y4jj = Vector{typeof(u)}()
+  Y1jj = zero(noise_rate_prototype)
+  Y2jj = zero(noise_rate_prototype)
+  Y3jj = zero(noise_rate_prototype)
+  Y4jj = zero(noise_rate_prototype)
 
-  for k=1:m
-    push!(Y2jj,zero(u))
-    push!(Y3jj,zero(u))
-    push!(Y4jj,zero(u))
-  end
 
   tmp1 = zero(rate_prototype)
-  tmpg = zero(noise_rate_prototype)
+  tmpu = zero(u)
+  #tmpg = zero(noise_rate_prototype)
 
-  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,g4,k1,k2,k3,k4,Y200,Y300,Y400,Y2jj,Y3jj,Y4jj,tmp1,tmpg)
+  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jj,Y2jj,Y3jj,Y4jj,tmp1,tmpu)
 
 end

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1641,3 +1641,82 @@ end
 function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   NONConstantCache(real(uBottomEltypeNoUnits))
 end
+
+
+
+
+
+@cache struct NONCache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+  u::uType
+  uprev::uType
+
+  _dW::randType
+  _dZ::randType
+  chi1::randType
+  Ihat2::MType1
+
+  tab::tabType
+
+  g1::rateNoiseType
+  g2::Vector{rateNoiseType}
+  g3::Vector{rateNoiseType}
+  g4::Vector{rateNoiseType}
+
+  k1::rateType
+  k2::rateType
+  k3::rateType
+  k4::rateType
+
+  Y200::uType
+  Y300::uType
+  Y400::uType
+  Y2jj::Vector{uType}
+  Y3jj::Vector{uType}
+  Y4jj::Vector{uType}
+
+  tmp1::possibleRateType
+  tmpg::rateNoiseType
+
+end
+
+
+function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,
+                   noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,
+                   uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
+  if typeof(ΔW) <: Union{SArray,Number}
+    _dW = copy(ΔW)
+    _dZ = copy(ΔW)
+    chi1 = copy(ΔW)
+  else
+    _dW = zero(ΔW)
+    _dZ = zero(ΔW)
+    chi1 = zero(ΔW)
+  end
+  m = length(ΔW)
+  Ihat2 = zeros(eltype(ΔW), m, m)
+  tab = NONConstantCache(real(uBottomEltypeNoUnits))
+  g1 = zero(noise_rate_prototype)
+  g2 = [zero(noise_rate_prototype) for k=1:m]
+  g3 = [zero(noise_rate_prototype) for k=1:m]
+  g4 = [zero(noise_rate_prototype) for k=1:m]
+  k1 = zero(rate_prototype); k2 = zero(rate_prototype); k3 = zero(rate_prototype); k4 = zero(rate_prototype)
+
+  Y200 = zero(u)
+  Y300 = zero(u)
+  Y400 = zero(u)
+  Y2jj = Vector{typeof(u)}()
+  Y3jj = Vector{typeof(u)}()
+  Y4jj = Vector{typeof(u)}()
+
+  for k=1:m
+    push!(Y2jj,zero(u))
+    push!(Y3jj,zero(u))
+    push!(Y4jj,zero(u))
+  end
+
+  tmp1 = zero(rate_prototype)
+  tmpg = zero(noise_rate_prototype)
+
+  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,g4,k1,k2,k3,k4,Y200,Y300,Y400,Y2jj,Y3jj,Y4jj,tmp1,tmpg)
+
+end

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1579,7 +1579,7 @@ struct NONConstantCache{T} <: StochasticDiffEqConstantCache
   ajljj31::T
 
   aljjl21::T
-  ajljj31::T
+  aljjl31::T
 
   #quantile(Normal(),1/6)
   NORMAL_ONESIX_QUANTILE::T
@@ -1630,11 +1630,11 @@ function NONConstantCache(T::Type)
   ajljj31 = convert(T, 1)
 
   aljjl21 = convert(T, -1//2)
-  ajljj31 = convert(T, 1//2)
+  aljjl31 = convert(T, 1//2)
 
   NORMAL_ONESIX_QUANTILE = convert(T,-0.9674215661017014)
 
-  NONConstantCache(c01,c02,c03,c04,cj1,cj2,cj3,cj4,cjl2,cjl3,clj2,clj3,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,ajljj31,aljjl21,ajljj31,NORMAL_ONESIX_QUANTILE)
+  NONConstantCache(c01,c02,c03,c04,cj1,cj2,cj3,cj4,cjl2,cjl3,clj2,clj3,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,ajljj31,aljjl21,aljjl31,NORMAL_ONESIX_QUANTILE)
 end
 
 

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1646,7 +1646,7 @@ end
 
 
 
-@cache struct NONCache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct NONCache{uType,randType,MType1,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
@@ -1664,12 +1664,11 @@ end
   Y200::uType
   Y300::uType
   Y400::uType
-  Y1jj::rateNoiseType
-  Y2jj::rateNoiseType
-  Y3jj::rateNoiseType
-  Y4jj::rateNoiseType
+  Y1jajb::Array{uType}
+  Y2jajb::Array{uType}
+  Y3jajb::Array{uType}
+  Y4jajb::Array{uType}
 
-  tmp1::possibleRateType
   tmpu::uType
   #tmpg::rateNoiseType
 
@@ -1699,16 +1698,13 @@ function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,
   Y200 = zero(u)
   Y300 = zero(u)
   Y400 = zero(u)
-  Y1jj = zero(noise_rate_prototype)
-  Y2jj = zero(noise_rate_prototype)
-  Y3jj = zero(noise_rate_prototype)
-  Y4jj = zero(noise_rate_prototype)
+  Y1jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y2jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y3jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y4jajb = [zero(u) for ja=1:m, jb=1:m]
 
-
-  tmp1 = zero(rate_prototype)
   tmpu = zero(u)
-  #tmpg = zero(noise_rate_prototype)
 
-  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jj,Y2jj,Y3jj,Y4jj,tmp1,tmpu)
+  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jajb,Y2jajb,Y3jajb,Y4jajb,tmpu)
 
 end

--- a/src/perform_step/srk_weak.jl
+++ b/src/perform_step/srk_weak.jl
@@ -1251,16 +1251,18 @@ end
   # define three-point distributed random variables
   dW_scaled = W.dW / integrator.sqdt
   _dW = map(x -> calc_threepoint_random(integrator, NORMAL_ONESIX_QUANTILE, x), dW_scaled)
-
+  #@show _dW
   if !(typeof(W.dW) <: Number)
-    # define two-point distributed random variables
-    _dZ = map(x -> calc_twopoint_random(integrator, x),  W.dZ)
-    Ihat2 = zeros(eltype(W.dZ), m, m)
-    for k = 1:m
-      Ihat2[k, k] = _dW[k]
-      for l = 1:k-1
-        Ihat2[k, l] = _dW[l]
-        Ihat2[l, k] = _dZ[k]
+    if !is_diagonal_noise(integrator.sol.prob)
+      # define two-point distributed random variables
+      _dZ = map(x -> calc_twopoint_random(integrator, x),  W.dZ)
+      Ihat2 = zeros(eltype(W.dZ), m, m)
+      for k = 1:m
+        Ihat2[k, k] = _dW[k]
+        for l = 1:k-1
+          Ihat2[k, l] = _dW[l]
+          Ihat2[l, k] = _dZ[k]
+        end
       end
     end
   end
@@ -1269,123 +1271,145 @@ end
   k1 = integrator.f(uprev,p,t)
   g1 = integrator.g(uprev,p,t)
 
-  # stage 2
-  Y200 = uprev + a0021*k1*dt
-  if typeof(W.dW) <: Number
-    Y200 += a0j21*g1*_dW
-    Y2jj = uprev + aj021*k1*dt + ajj21*g1*_dW
-    g2 = integrator.g(Y2jj,p,t)
+  Y100 = k1*dt
+  if is_diagonal_noise(integrator.sol.prob)
+    Y1jj = g1.*_dW
   else
-    Y2jj = [uprev .+ aj021*k1*dt for j=1:m]
-    # Y2jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
+    Y1jj = g1*_dW
+  end
+  #@show Y100, Y1jj
+  # stage 2
+  Y200 = uprev + a0021*Y100
+
+  if typeof(W.dW) <: Number
+    Y200 += a0j21*Y1jj
+    tmpu = uprev + aj021*Y100 + ajj21*Y1jj
+    g2 = integrator.g(tmpu,p,t)
+    Y2jj = g2*_dW
+  else
+    Y2jj = zero(g1)
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. Y200 = Y200 + a0j21*g1[j]*_dW[j]
-        @.. Y2jj[j] = Y2jj[j] + ajj21*g1[j]*_dW[j]
-        #@show Y2jj
-        # for l=j+1:m
-        #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[j]*_dZ[l]
-        # end
+        @.. Y200 = Y200 + a0j21*Y1jj[j]
+        tmpu = uprev + aj021*Y100 .+ ajj21*Y1jj[j]
+        g2 = integrator.g(tmpu,p,t)
+        Y2jj[j] = g2[j]*_dW[j]
       end
     else
       for j=1:m
-        @.. Y200 = Y200 + a0j21*g1[:,j]*_dW[j]
-        @.. Y2jj[j] = Y2jj[j] + ajj21*g1[:,j]*_dW[j]
-        # for l=j+1:m
-        #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[:,j]
-        # end
+        Y200 += a0j21*Y100[:,j]
+        tmpu = uprev + aj021*Y100 + ajj21*Y1jj[:,j]
+        g2 = integrator.g(tmpu,p,t)
+        Y2jj[j,j] = g2[:,j]*_dW[j]
       end
     end
-    g2 = [integrator.g(Y2jj[j],p,t) for j=1:m]
-    # g2jl = [integrator.g(Y2jl[j],p,t) for j=1:m]
+
   end
   k2 = integrator.f(Y200,p,t)
+  Y200 = k2*dt
+
+  #@show Y200, Y2jj
 
   # stage 3
-  Y300 = uprev + a0032*k2*dt
+  Y300 = uprev + a0032*Y200
   if typeof(W.dW) <: Number
-    Y300 += a0j31*g1*_dW + a0j32*g2*_dW
-    Y3jj = uprev + ajj31*g1*_dW + ajj32*g2*_dW
-    g3 = integrator.g(Y3jj,p,t)
+    Y300 += a0j31*Y1jj + a0j32*Y2jj
+    tmpu = uprev + ajj31*Y1jj + ajj32*Y2jj
+    g3 = integrator.g(tmpu,p,t)
+    Y3jj = g3*_dW
   else
-    Y3jj = [copy(uprev) for j=1:m]
-    # Y3jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
+    Y3jj = zero(g1)
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. Y300 = Y300 + (a0j31*g1[j] + a0j32*g2[j][j])*_dW[j]
-        @.. Y3jj[j] = Y3jj[j] + (ajj31*g1[j] + ajj32*g2[j][j])*_dW[j]
+        @.. Y300 = Y300 +  a0j31*Y1jj[j] + a0j32*Y2jj[j]
+        tmpu = @.. uprev + ajj31*Y1jj[j] + ajj32*Y2jj[j]
         for l=1:m
           if l!=j
-            @.. Y3jj[j] = Y3jj[j] + (ajl31*g1[l] + ajl32*g2[l][l])*_dW[l]
+            tmpu += ajl31*Y1jj[l] + ajl32*Y2jj[j]
           end
         end
+        g3 = integrator.g(tmpu,p,t)
+        Y3jj[j] = g3[j]*_dW[j]
       end
     else
       for j=1:m
-        @.. Y300 = Y300 + a0j31*g1[:,j]*_dW[j] + a0j32*g2[j][:,j]*_dW[j]
-        @.. Y3jj[j] = Y3jj[j] + ajj31*g1[:,j]*_dW[j] + ajj32*g2[j][:,j]*_dW[j]
+        Y300 +=  a0j31*Y1jj[:,j] + a0j32*Y2jj[:,j]
+        tmpu = ajj31*Y1jj[:,j] + ajj32*Y2jj[:,j]
         for l=1:m
           if l!=j
-            @.. Y3jj[j] = Y3jj[j] + ajl31*g1[:,l]*_dW[l] + ajl32*g2[l][:,l]*_dW[l]
+            tmpu += ajl31*Y1jj[:,l] + ajl32*Y2jj[:,l]
           end
         end
+        g3 = integrator.g(tmpu,p,t)
+        Y3jj[j,j] = g3[:,j]*_dW[j]
       end
     end
-    g3 = [integrator.g(Y3jj[j],p,t) for j=1:m]
+
   end
   k3 = integrator.f(Y300,p,t)
+  Y300 = k3*dt
+
+  #@show Y300, Y3jj
 
   # stage 4
-  Y400 = uprev + a0043*k3*dt
+  Y400 = uprev + a0043*Y300
 
   if typeof(W.dW) <: Number
-    Y400 += a0j41*g1*_dW
-    Y4jj = uprev + aj041*k1*dt + ajj41*g1*_dW + ajj42*g2*_dW + ajj43*g3*_dW
-    g4 = integrator.g(Y4jj,p,t)
+    Y400 += a0j41*Y1jj
+    tmpu = @.. uprev + aj041*Y100 + ajj41*Y1jj + ajj42*Y2jj + ajj43*Y3jj
+    g4 = integrator.g(tmpu,p,t)
+    Y4jj = g4*_dW
   else
-    Y4jj = [uprev + aj041*k1*dt for j=1:m]
+    Y4jj = zero(g1)
     # Y4jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. Y400 = Y400 + a0j41*g1[j]*_dW[j]
-        @.. Y4jj[j] = Y4jj[j] + (ajj41*g1[j] + ajj42*g2[j][j] + ajj43*g3[j][j])*_dW[j]
+        @.. Y400 = Y400 + a0j41*Y1jj
+        tmpu = uprev + aj041*Y100 .+ (ajj41*Y1jj[j] + ajj42*Y2jj[j] + ajj43*Y3jj[j])
         for l=1:m
           if l!=j
-            @.. Y4jj[j] = Y4jj[j] + (ajl41*g1[l] + ajl42*g2[l][l])*_dW[l]
+            tmpu += ajl41*Y1jj[l] + ajl42*Y2jj[l]
           end
         end
+        g4 = integrator.g(tmpu,p,t)
+        Y4jj[j] = g4[j]*_dW[j]
       end
     else
       for j=1:m
-        @.. Y400 = Y400 + a0j41*g1[:,j]*_dW[j]
-        @.. Y4jj[j] = Y4jj[j] + ajj41*g1[:,j]*_dW[j] + ajj42*g2[j][:,j]*_dW[j] + ajj43*g3[j][:,j]*_dW[j]
+        Y400 += a0j41*Y1jj[:,j]
+        tmpu = uprev + ajj41*Y1jj[:,j] + ajj42*Y2jj[:,j] + ajj43*Y3jj[:,j]
         for l=1:m
           if l!=j
-            @.. Y4jj[j] = Y4jj[j] + ajl41*g1[:,l]*_dW[l] + ajl42*g2[l][:,l]*_dW[l]
+            tmpu += ajl41*Y1jj[:,l] + ajl42*Y1jj[:,l]
           end
         end
+        g4 = integrator.g(tmpu,p,t)
+        Y4jj[j,j] = g4[:,j]*_dW[j]
       end
     end
-    g4 = [integrator.g(Y4jj[j],p,t) for j=1:m]
   end
   k4 = integrator.f(Y400,p,t)
+  Y400 = k4*dt
+
+  #@show Y400, Y4jj
 
   # add stages together
-  u = uprev + (c01*k1+c02*k2+c03*k3+c04*k4)*dt
+  u = uprev + c01*Y100+c02*Y200+c03*Y300+c04*Y400
+
   if typeof(W.dW) <: Number
-    u += (cj1*g1 + cj2*g2 + cj3*g3 + cj4*g4)*_dW
+    u += cj1*Y1jj + cj2*Y2jj + cj3*Y3jj + cj4*Y4jj
   else
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. u = u + (cj1*g1[j] + cj2*g2[j][j] + cj3*g3[j][j] + cj4*g4[j][j])*_dW[j]
+        u[j] += cj1*Y1jj[j] + cj2*Y2jj[j] + cj3*Y3jj[j] + cj4*Y4jj[j]
       end
     else
       for j=1:m
-        @.. u = u + (cj1*g1[j] + cj2*g2[j][:,j] + cj3*g3[j][:,j] + cj4*g4[j][:,j])*_dW[j]
+        u += cj1*Y1jj[:,j] + cj2*Y2jj[:,j] + cj3*Y3jj[:,j] + cj4*Y4jj[:,j]
       end
     end
   end
-
+  #@show u
   integrator.u = u
 
 end
@@ -1393,7 +1417,7 @@ end
 
 @muladd function perform_step!(integrator,cache::NONCache,f=integrator.f)
   @unpack t,dt,uprev,u,W,p = integrator
-  @unpack _dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,g4,k1,k2,k3,k4,Y200,Y300,Y400,Y2jj,Y3jj,Y4jj,tmp1,tmpg = cache
+  @unpack _dW,_dZ,chi1,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jj,Y2jj,Y3jj,Y4jj,tmp1,tmpu = cache
   @unpack c01,c02,c03,c04,cj1,cj2,cj3,cj4,cjl2,cjl3,clj2,clj3,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,ajljj31,aljjl21,ajljj31,NORMAL_ONESIX_QUANTILE = cache.tab
 
   m = length(W.dW)
@@ -1403,135 +1427,164 @@ end
 
   if !(typeof(W.dW) <: Number) || m > 1
     # define two-point distributed random variables
-    calc_twopoint_random!(_dZ,integrator,W.dZ)
-    for k = 1:m
-      Ihat2[k, k] = _dW[k]
-      for l = 1:k-1
-        Ihat2[k, l] = _dW[l]
-        Ihat2[l, k] = _dZ[k]
+    if !is_diagonal_noise(integrator.sol.prob)
+      calc_twopoint_random!(_dZ,integrator,W.dZ)
+      for k = 1:m
+        Ihat2[k, k] = _dW[k]
+        for l = 1:k-1
+          Ihat2[k, l] = _dW[l]
+          Ihat2[l, k] = _dZ[k]
+        end
       end
     end
   end
+  #@show _dW, dt
   # compute stage values
-  integrator.f(k1,uprev,p,t)
-  integrator.g(g1,uprev,p,t)
+  # stage 1
+  integrator.f(ktmp,uprev,p,t)
+  integrator.g(gtmp,uprev,p,t)
+
+  @.. Y100 = ktmp*dt
+  if is_diagonal_noise(integrator.sol.prob)
+    @.. Y1jj = gtmp*_dW
+  else
+    mul!(tmp1,gtmp,_dW)
+    @.. Y1jj = tmp1
+  end
+
+  #@show Y100, Y1jj
 
   # stage 2
-  @.. Y200 = uprev + a0021*k1*dt
+  @.. Y200 = uprev + a0021*Y100
 
   if !is_diagonal_noise(integrator.sol.prob) || typeof(W.dW) <: Number
-    mul!(tmp1,g1,_dW)
-    #if typeof(W.dW) <: Number
-    # @.. Y200 = Y200+a0j21*tmp1
-    #else
-    for j=1:m
-      @.. Y200 = Y200 + a0j21*tmp1
-      @.. Y2jj[j] = uprev + aj021*k1*dt + ajj21*tmp1
-      # for l=j+1:m
-      #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[:,j]
-      # end
-    end
+    # mul!(tmp1,g1,_dW)
+    # #if typeof(W.dW) <: Number
+    # # @.. Y200 = Y200+a0j21*tmp1
+    # #else
+    # for j=1:m
+    #   @.. Y200 = Y200 + a0j21*tmp1
+    #   @.. Y2jj[j] = uprev + aj021*k1*dt + ajj21*tmp1
+    #   # for l=j+1:m
+    #   #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[:,j]
+    #   # end
+    #   integrator.g(g2[j],Y2jj[j],p,t)
+    # end
   else
     for j=1:m
-      @.. Y200 = Y200 + a0j21*g1[j]*_dW[j]
-      @.. Y2jj[j] = uprev + aj021*k1*dt + ajj21*g1[j]*_dW[j]
-      integrator.g(g2[j],Y2jj[j],p,t)
+      @.. Y200 = Y200 + a0j21*Y1jj[j]
+      @.. tmpu = uprev + aj021*Y100 + ajj21*Y1jj[j]
+      integrator.g(gtmp,tmpu,p,t)
+      Y2jj[j] = gtmp[j]*_dW[j]
     end
   end
-  integrator.f(k2,Y200,p,t)
+  integrator.f(ktmp,Y200,p,t)
+  @.. Y200 = ktmp*dt
+
+  #@show Y200, Y2jj
 
   # stage 3
-  @.. Y300 = uprev + a0032*k2*dt
+  @.. Y300 = uprev + a0032*Y200
+
   if typeof(W.dW) <: Number
-    @.. Y300 = Y300 + a0j31*g1*_dW + a0j32*g2*_dW
-    @.. Y3jj = uprev + ajj31*g1*_dW + ajj32*g2*_dW
-    integrator.g(g3,Y3jj,p,t)
+    @.. Y300 = Y300 + a0j31*Y1jj + a0j32*Y2jj
+    @.. tmpu = uprev + ajj31*Y1jj + ajj32*Y2jj
+    integrator.g(gtmp,tmpu,p,t)
+    @.. Y3jj = gtmp*_dW
   else
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. Y300 = Y300 + (a0j31*g1[j] + a0j32*g2[j][j])*_dW[j]
-        @.. Y3jj[j] = uprev + (ajj31*g1[j] + ajj32*g2[j][j])*_dW[j]
+        @.. Y300 = Y300 + a0j31*Y1jj[j] + a0j32*Y2jj[j]
+        @.. tmpu = uprev + ajj31*Y1jj[j] + ajj32*Y2jj[j]
         for l=1:m
           if l!=j
-            @.. Y3jj[j] = Y3jj[j] + (ajl31*g1[l] + ajl32*g2[l][l])*_dW[l]
+            @.. tmpu = tmpu + ajl31*Y1jj[l] + ajl32*Y2jj[l]
           end
         end
-        integrator.g(g3[j],Y3jj[j],p,t)
+        integrator.g(gtmp,tmpu,p,t)
+        Y3jj[j] = gtmp[j]*_dW[j]
       end
-    else
-      for j=1:m
-        g1j = @view g1[:,j]
-        g2j = @view g2[j][:,j]
-        @.. Y300 = Y300 + (a0j31*g1j + a0j32*g2j)*_dW[j]
-        @.. Y3jj[j] = uprev + (ajj31*g1j + ajj32*g2j)*_dW[j]
-        for l=1:m
-          if l!=j
-            g1l = @view g1[:,l]
-            g2l = @view g2[l][:,l]
-            @.. Y3jj[j] = Y3jj[j] + (ajl31*g1l + ajl32*g2l)*_dW[l]
-          end
-        end
-        integrator.g(g3[j],Y3jj[j],p,t)
-      end
+    # else
+    #   for j=1:m
+    #     g1j = @view g1[:,j]
+    #     g2j = @view g2[j][:,j]
+    #     @.. Y300 = Y300 + (a0j31*g1j + a0j32*g2j)*_dW[j]
+    #     @.. Y3jj[j] = uprev + (ajj31*g1j + ajj32*g2j)*_dW[j]
+    #     for l=1:m
+    #       if l!=j
+    #         g1l = @view g1[:,l]
+    #         g2l = @view g2[l][:,l]
+    #         @.. Y3jj[j] = Y3jj[j] + (ajl31*g1l + ajl32*g2l)*_dW[j]
+    #       end
+    #     end
+    #     integrator.g(g3[j],Y3jj[j],p,t)
+    #   end
     end
   end
-  integrator.f(k3,Y300,p,t)
+  integrator.f(ktmp,Y300,p,t)
+  @.. Y300 = ktmp*dt
+
+  #@show Y300, Y3jj
 
   # stage 4
-  @.. Y400 = uprev + a0043*k3*dt
+  @.. Y400 = uprev + a0043*Y300
 
   if typeof(W.dW) <: Number
-    @.. Y400 =  Y400 + a0j41*g1*_dW
-    @.. Y4jj = uprev + aj041*k1*dt + ajj41*g1*_dW + ajj42*g2*_dW + ajj43*g3*_dW
-    integrator.g(g4,Y4jj,p,t)
+    @.. Y400 =  Y400 + a0j41*Y1jj
+    @.. tmpu = uprev + aj041*Y100 + ajj41*Y1jj + ajj42*Y2jj + ajj43*Y3jj
+    integrator.g(gtmp,tmpu,p,t)
+    @.. Y4jj = gtmp*_dW
   else
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. Y400 = Y400 + a0j41*g1[j]*_dW[j]
-        @.. Y4jj[j] = uprev + aj041*k1*dt + (ajj41*g1[j] + ajj42*g2[j][j] + ajj43*g3[j][j])*_dW[j]
+        @.. Y400 = Y400 + a0j41*Y1jj[j]
+        @.. tmpu = uprev + aj041*Y100 + ajj41*Y1jj[j] + ajj42*Y2jj[j] + ajj43*Y3jj[j]
         for l=1:m
           if l!=j
-            @.. Y4jj[j] = Y4jj[j] + (ajl41*g1[l] + ajl42*g2[l][l])*_dW[l]
+            @.. tmpu = tmpu + ajl41*Y1jj[l] + ajl42*Y2jj[l]
           end
         end
-        integrator.g(g4[j],Y4jj[j],p,t)
+        integrator.g(gtmp,tmpu,p,t)
+        Y4jj[j] = gtmp[j]*_dW[j]
       end
-    else
-      for j=1:m
-        g1j = @view g1[:,j]
-        g2j = @view g2[j][:,j]
-        g3j = @view g3[j][:,j]
-        @.. Y400 = Y400 + a0j41*g1j*_dW[j]
-        @.. Y4jj[j] = uprev + aj041*k1*dt+ (ajj41*g1j + ajj42*g2j + ajj43*g3j)*_dW[j]
-        for l=1:m
-          if l!=j
-            @.. Y4jj[j] = Y4jj[j] + (ajl41*g1j + ajl42*g2j)*_dW[l]
-          end
-        end
-        integrator.g(g4[j],Y4jj[j],p,t)
-      end
+    # else
+    #   for j=1:m
+    #     g1j = @view g1[:,j]
+    #     g2j = @view g2[j][:,j]
+    #     g3j = @view g3[j][:,j]
+    #     @.. Y400 = Y400 + a0j41*g1j*_dW[j]
+    #     @.. Y4jj[j] = uprev + aj041*k1*dt+ (ajj41*g1j + ajj42*g2j + ajj43*g3j)*_dW[j]
+    #     for l=1:m
+    #       if l!=j
+    #         @.. Y4jj[j] = Y4jj[j] + (ajl41*g1j + ajl42*g2j)*_dW[j]
+    #       end
+    #     end
+    #     integrator.g(g4[j],Y4jj[j],p,t)
+    #   end
     end
   end
-  integrator.f(k4,Y400,p,t)
+  integrator.f(ktmp,Y400,p,t)
+  @.. Y400 = ktmp*dt
+  #@show Y400,Y4jj
 
   # add stages together
-  @.. u = uprev + (c01*k1+c02*k2+c03*k3+c04*k4)*dt
+  @.. u = uprev + c01*Y100+c02*Y200+c03*Y300+c04*Y400
   if typeof(W.dW) <: Number
-    @.. u = u + (cj1*g1 + cj2*g2 + cj3*g3 + cj4*g4)*_dW
+    @.. u = u + cj1*Y1jj + cj2*Y2jj + cj3*Y3jj + cj4*Y4jj
   else
     if is_diagonal_noise(integrator.sol.prob)
       for j=1:m
-        @.. u = u + (cj1*g1[j] + cj2*g2[j][j] + cj3*g3[j][j] + cj4*g4[j][j])*_dW[j]
+        u[j] = u[j] + cj1*Y1jj[j] + cj2*Y2jj[j] + cj3*Y3jj[j] + cj4*Y4jj[j]
       end
-    else
-      for j=1:m
-        g1j = @view g1[:,j]
-        g2j = @view g2[j][:,j]
-        g3j = @view g3[j][:,j]
-        g4j = @view g4[j][:,j]
-        @.. u = u + (cj1*g1j + cj2*g2j + cj3*g3j + cj4*g4j)*_dW[j]
-      end
+    # else
+    #   for j=1:m
+    #     g1j = @view g1[:,j]
+    #     g2j = @view g2[j][:,j]
+    #     g3j = @view g3[j][:,j]
+    #     g4j = @view g4[j][:,j]
+    #     @.. u = u + (cj1*g1j + cj2*g2j + cj3*g3j + cj4*g4j)*_dW[j]
+    #   end
     end
   end
-
+  #@show u
 end

--- a/src/perform_step/srk_weak.jl
+++ b/src/perform_step/srk_weak.jl
@@ -1270,40 +1270,122 @@ end
   g1 = integrator.g(uprev,p,t)
 
   # stage 2
-  Y200 = uprev + a0021*k1
-  Y2jj = Vector{typeof(uprev)}[uprev + aj021*k1 for j=1:m]
-  Y2jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
-  if !is_diagonal_noise(integrator.sol.prob) || typeof(W.dW) <: Number
-    if typeof(W.dW) <: Number
-      Y200 += a0j21*g1
-      @.. Y2jj = Y2jj + ajj21*g1
-    else
-      for j=1:m
-        @.. Y200 = Y200 + a0j21*g1[:,j]
-        @.. Y2jj[j] = Y2jj[j] + ajj21*g1[:,j]
-        for l=j+1:m
-          @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[:,j]
-        end
-      end
-    end
+  Y200 = uprev + a0021*k1*dt
+  if typeof(W.dW) <: Number
+    Y200 += a0j21*g1*_dW
+    Y2jj = uprev + aj021*k1*dt + ajj21*g1*_dW
+    g2 = integrator.g(Y2jj,p,t)
   else
-    for j=1:m
-      @.. Y200 = Y200 + a0j21*g1[j]
-      @.. Y2jj[j] = Y2jj[j] + ajj21*g1[j]
-      for l=j+1:m
-        @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[j]
+    Y2jj = [uprev .+ aj021*k1*dt for j=1:m]
+    # Y2jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
+    if is_diagonal_noise(integrator.sol.prob)
+      for j=1:m
+        @.. Y200 = Y200 + a0j21*g1[j]*_dW[j]
+        @.. Y2jj[j] = Y2jj[j] + ajj21*g1[j]*_dW[j]
+        #@show Y2jj
+        # for l=j+1:m
+        #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[j]*_dZ[l]
+        # end
       end
+  #   else
+  #     for j=1:m
+  #       @.. Y200 = Y200 + a0j21*g1[:,j]
+  #       @.. Y2jj[j] = Y2jj[j] + ajj21*g1[:,j]
+  #       # for l=j+1:m
+  #       #   @.. Y2jl[j,l] = Y2jl[j,l] + aljjl21*g1[:,j]
+  #       # end
+  #     end
     end
+    g2 = [integrator.g(Y2jj[j],p,t) for j=1:m]
+    # g2jl = [integrator.g(Y2jl[j],p,t) for j=1:m]
   end
   k2 = integrator.f(Y200,p,t)
-  g2 = [integrator.g(Y2jj[j],p,t) for j=1:m]
-  g2jl = [integrator.g(Y2jl[j],p,t) for j=1:m]
 
   # stage 3
-  
+  Y300 = uprev + a0032*k2*dt
+  if typeof(W.dW) <: Number
+    Y300 += a0j31*g1*_dW + a0j32*g2*_dW
+    Y3jj = uprev + ajj31*g1*_dW + ajj32*g2*_dW
+    g3 = integrator.g(Y3jj,p,t)
+  else
+    Y3jj = [copy(uprev) for j=1:m]
+    # Y3jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
+    if is_diagonal_noise(integrator.sol.prob)
+      for j=1:m
+        @.. Y300 = Y300 + (a0j31*g1[j] + a0j32*g2[j][j])*_dW[j]
+        @.. Y3jj[j] = Y3jj[j] + (ajj31*g1[j] + ajj32*g2[j][j])*_dW[j]
+        for l=1:m
+          if l!=j
+            @.. Y3jj[j] = Y3jj[j] + (ajl31*g1[l] + ajl32*g2[l][l])*_dW[l]
+          end
+        end
+      end
+  #   else
+  #     for j=1:m
+  #       @.. Y300 = Y300 + a0j31*g1[:,j] + a0j32*g2[j][:,j]
+  #       @.. Y3jj[j] = Y3jj[j] + ajj31*g1[:,j] + ajj32*g2[j][:,j]
+  #       for l=1:m
+  #         if l!=j
+  #           @.. Y3jj[j] = Y3jj[j] + ajl31*g1[:,l] + ajl32*g2[l][:,l]
+  #         end
+  #       end
+  #     end
+    end
+    g3 = [integrator.g(Y3jj[j],p,t) for j=1:m]
+  end
+  k3 = integrator.f(Y300,p,t)
+
+  # stage 4
+  Y400 = uprev + a0043*k3*dt
+
+  if typeof(W.dW) <: Number
+    Y400 += a0j41*g1*_dW
+    Y4jj = uprev + aj041*k1*dt + ajj41*g1*_dW + ajj42*g2*_dW + ajj43*g3*_dW
+    g4 = integrator.g(Y4jj,p,t)
+  else
+    Y4jj = [uprev + aj041*k1*dt for j=1:m]
+    # Y4jl = Matrix{typeof(uprev)}[uprev for j=1:m, l=1:m]
+    if is_diagonal_noise(integrator.sol.prob)
+      for j=1:m
+        @.. Y400 = Y400 + a0j41*g1[j]*_dW[j]
+        @.. Y4jj[j] = Y4jj[j] + (ajj41*g1[j] + ajj42*g2[j][j] + ajj43*g3[j][j])*_dW[j]
+        for l=1:m
+          if l!=j
+            @.. Y4jj[j] = Y4jj[j] + (ajl41*g1[l] + ajl42*g2[l][l])*_dW[l]
+          end
+        end
+      end
+  #   else
+  #     for j=1:m
+  #       @.. Y400 = Y400 + a0j41*g1[:,j]
+  #       @.. Y4jj[j] = Y4jj[j] + ajj41*g1[:,j] + ajj42*g2[j][:,j] + ajj43*g3[j][:,j]
+  #       for l=1:m
+  #         if l!=j
+  #           @.. Y4jj[j] = Y4jj[j] + ajl41*g1[:,l] + ajl42*g2[l][:,l]
+  #         end
+  #       end
+  #     end
+    end
+    g4 = [integrator.g(Y4jj[j],p,t) for j=1:m]
+  end
+  k4 = integrator.f(Y400,p,t)
 
   # add stages together
   u = uprev + (c01*k1+c02*k2+c03*k3+c04*k4)*dt
+  if typeof(W.dW) <: Number
+    u += (cj1*g1 + cj2*g2 + cj3*g3 + cj4*g4)*_dW
+  else
+    if is_diagonal_noise(integrator.sol.prob)
+      for j=1:m
+        @.. u = u + (cj1*g1[j] + cj2*g2[j][j] + cj3*g3[j][j] + cj4*g4[j][j])*_dW[j]
+      end
+  #   else
+  #     for j=1:m
+  #       @.. u = u + (cj1*g1[j] + cj2*g2[j][:,j] + cj3*g3[j][:,j] + cj4*g4[j][:,j])*Ihat2[j,j]
+  #     end
+    end
+  end
 
   integrator.u = u
+
 end

--- a/test/ode_convergence_regression.jl
+++ b/test/ode_convergence_regression.jl
@@ -55,3 +55,6 @@ sim2 = test_convergence(dts,prob, RS1(),trajectories=20)
 @test abs(sim2.𝒪est[:l∞]-2) <.1
 sim2 = test_convergence(dts,prob, RS2(),trajectories=20)
 @test abs(sim2.𝒪est[:l∞]-3) <.1
+
+sim2 = test_convergence(dts,prob, NON(),trajectories=20)
+@test abs(sim2.𝒪est[:l∞]-4) <.1

--- a/test/sde/sde_rosslerorder_tests.jl
+++ b/test/sde/sde_rosslerorder_tests.jl
@@ -38,3 +38,7 @@ RS1_tab = constructRS1()
 
 RS2_tab = constructRS2()
 @test minimum(checkRSOrder(RS2_tab))
+
+# Komori's NON
+NON_tab = constructNON()
+@test minimum(checkNONOrder(NON_tab))

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -193,7 +193,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts,
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
-using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
+
 """
  Test non-commutative noise SDEs (iip)
 """
@@ -249,6 +249,19 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("RS2:", m)
 
+numtraj = Int(1e6)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test -(m-2) < 0.3
+
+println("NON:", m)
+
 """
  Test Diagonal noise SDEs (iip)
 """
@@ -301,3 +314,19 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test -(m-2) < 0.3
 
 println("RS2:", m)
+
+
+numtraj = Int(5e6)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test -(m-2) < 0.3
+
+println("NON:", m)
+
+using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -1,6 +1,8 @@
 """
  Tests for  https://link.springer.com/article/10.1007/s10543-007-0130-3 with test problems as in the paper.
  RS1, RS2
+ and for https://www.sciencedirect.com/science/article/pii/S0377042706003906
+ NON
 """
 
 

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -193,6 +193,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts,
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
+println("NON:", m)
 
 """
  Test non-commutative noise SDEs (iip)
@@ -329,4 +330,5 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
-using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
+#using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
+#savefig(convergence_plot, "NON_diagonal_noise.png")

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -23,23 +23,6 @@ function generate_weak_solutions(prob, alg, dts, numtraj; ensemblealg=EnsembleTh
   return sols
 end
 
-function strat_weak_errors(prob, alg, dts, numtraj; ensemblealg=EnsembleThreads())
-  errors = Array{typeof(prob.prob.u0)}(undef, length((dts)), 2)
-  for i in 1:length(dts)
-    sol = solve(prob, alg, dt=dts[i], #save_start=false,save_everystep=true,weak_timeseries_errors=false,weak_dense_errors=false,
-    trajectories=numtraj, adaptive=false)
-
-    computed_exp = Statistics.mean([_sol.u[end] for _sol in sol])
-    true_exp1 = prob.prob.u0*exp(1.0*(prob.prob.p[1]+0.5*prob.prob.p[2]^2))
-    #true_exp1b = prob.u0*exp(1.0*(prob.p[1][1]))
-    true_exp2 = Statistics.mean([_sol.u_analytic[end] for _sol in sol])
-    println(i)
-    errors[i,1] = LinearAlgebra.norm(computed_exp-true_exp1)
-    errors[i,2] = LinearAlgebra.norm(computed_exp-true_exp2)
-  end
-  return errors
-end
-
 function prob_func(prob, i, repeat)
     remake(prob,seed=seeds[i])
 end
@@ -77,25 +60,8 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) - u₀*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 println("RS1:", m)
-
-#using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-#savefig(convergence_plot, "RS1-final-"*string(numtraj)*".pdf")
-
-# f_strat(u0,p,t,W) = @.(u0*exp(p[1]*t+p[2]*W))
-# seed = 100
-# Random.seed!(seed)
-# seeds = rand(UInt, numtraj)
-# prob_test = SDEProblem(SDEFunction(f,g,analytic=f_strat),g,u₀,tspan,p)
-# ensemble_test = EnsembleProblem(prob_test;
-#         #output_func = (sol,i) -> (h1(sol[end]),false),
-#         prob_func = prob_func
-#         )
-# errors2 = @time strat_weak_errors(ensemble_test, RS1(), dts, numtraj, ensemblealg=EnsembleThreads())
-#
-# @test m ≈ log(errors2[end,1]/errors2[1,1])/log(dts[end]/dts[1])
-# @test -(log(errors2[end,2]/errors2[1,2])/log(dts[end]/dts[1])-2) < 0.3
 
 
 seed = 100
@@ -106,7 +72,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) - u₀*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("RS2:", m)
 
@@ -127,7 +93,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("NON:", m)
 
@@ -154,7 +120,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts,
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 println("RS1:", m)
 
 
@@ -172,7 +138,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts,
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.37
 
 println("RS1:", m)
 
@@ -192,6 +158,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts,
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
 
 println("NON:", m)
 
@@ -232,7 +199,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("RS1:", m)
 
@@ -246,7 +213,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("RS2:", m)
 
@@ -259,9 +226,11 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("NON:", m)
+
+using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
 
 """
  Test Diagonal noise SDEs (iip)
@@ -299,7 +268,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.37
 
 println("RS1:", m)
 
@@ -312,7 +281,7 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("RS2:", m)
 
@@ -326,9 +295,8 @@ _solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test -(m-2) < 0.3
+@test abs(m-2) < 0.3
 
 println("NON:", m)
 
 #using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
-#savefig(convergence_plot, "NON_diagonal_noise.png")

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -38,7 +38,7 @@ u₀ = 0.1
 p = [1.5, 0.1]
 f(u,p,t) = p[1]*u
 g(u,p,t) = p[2]*u
-dts = 1 .//2 .^(5:-1:1)
+dts = 1 .//2 .^(5:-1:0)
 tspan = (0.0,1.0)
 
 h1(z) = z
@@ -72,12 +72,10 @@ _solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, e
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) - u₀*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test abs(m-2) < 0.3
+@test abs(m-2) < 0.37
 
 println("RS2:", m)
 
-dts = 1 .//2 .^(5:-1:0)
-numtraj = Int(1e5)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
@@ -142,7 +140,6 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("RS1:", m)
 
-dts = 1 .//2 .^(5:-1:0)
 numtraj = Int(1e5)
 seed = 100
 Random.seed!(seed)
@@ -153,8 +150,7 @@ ensemble_prob = EnsembleProblem(prob;
         output_func = (sol,i) -> (h1(sol[end]),false),
         prob_func = prob_func
         )
-_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts,
-  numtraj, ensemblealg=EnsembleThreads())
+_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
@@ -230,7 +226,6 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
-using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)
 
 """
  Test Diagonal noise SDEs (iip)
@@ -248,7 +243,7 @@ function g3!(du,u,p,t)
   du[1] = 1//10*u[1]
   du[2] = 1//10*u[2]
 end
-dts = 1 .//2 .^(5:-1:1)
+dts = 1 .//2 .^(4:-1:0)
 tspan = (0.0,1.0)
 
 h3(z) = z^2 # == 1//10**exp(3//2*t) if h3(z) = z and  == 1//100**exp(301//100*t) if h3(z) = z^2 )
@@ -272,7 +267,7 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("RS1:", m)
 
-numtraj = Int(1e6)
+numtraj = Int(4e4)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
@@ -286,7 +281,7 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 println("RS2:", m)
 
 
-numtraj = Int(5e6)
+numtraj = Int(1e6)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
@@ -298,5 +293,3 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON:", m)
-
-#using Plots; convergence_plot = plot(dts, errors, xaxis=:log, yaxis=:log)


### PR DESCRIPTION
The scalar noise tests are passing for the inplace and out-of-place version of NON from issue #182 . 
Also ODE tests are passing (4th order, basically standard RK4).
I have checked that all coefficients in the paper satisfy the order conditions. 

The diagonal noise `perform_step`  actually does in one step what I expect it to do, i.e.,  for the SDE
```
using StochasticDiffEq
using Random
u₀ = [0.1,0.1]
function f3!(du,u,p,t)
  du[1] = p[1]*u[1]
  du[2] = p[1]*u[2]
end
function g3!(du,u,p,t)
  du[1] = p[2]*u[1]
  du[2] = p[2]*u[1]
end
tspan = (0.0,1.0)
p = [299//200, 1//10]

prob = SDEProblem(f3!,g3!,u₀,tspan,p)
ensemble_prob = EnsembleProblem(prob;
        prob_func = prob_func
        )
sol = solve(ensemble_prob, NON(); dt=1., trajectories=numtraj, ensemblealg=EnsembleThreads())
# [0.469606, 0.409286]
```
So my expectation is that I misunderstand something in the stage values (Y^{j,l}) in the paper (or something else is odd..)

The convergence plot for diagonal noise is shown in the attached figure. The slope is ~ 0.8.  Other solvers in the Stratonovich sense such as `RS1` or `EulerHeun`  are passing the test. Therefore, the example should be ok. 

![NON_diagonal_noise](https://user-images.githubusercontent.com/42201748/85952924-e6eb2c80-b96c-11ea-8cde-6f9080b8bd44.png)
