### PR TITLE
Fix logging for `progress=true` by wrapping log-level `-1` in `LogLevel(-1)`

### DIFF
--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -173,7 +173,7 @@ end
     handle_callbacks!(integrator)
   end
   if integrator.opts.progress && integrator.iter%integrator.opts.progress_steps==0
-    @logmsg(-1,
+    @logmsg(LogLevel(-1),
     integrator.opts.progress_name,
     _id = :StochasticDiffEq,
     message=integrator.opts.progress_message(integrator.dt,integrator.u,integrator.p,integrator.t),
@@ -218,7 +218,7 @@ end
   resize!(integrator.sol.t,integrator.saveiter)
   resize!(integrator.sol.u,integrator.saveiter)
   if integrator.opts.progress
-    @logmsg(-1,
+    @logmsg(LogLevel(-1),
     integrator.opts.progress_name,
     _id = :StochasticDiffEq,
     message=integrator.opts.progress_message(integrator.dt,integrator.u,integrator.p,integrator.t),

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -104,7 +104,7 @@ function DiffEqBase.__init(
     error("The algorithm is not compatible with the chosen noise type. Please see the documentation on the solver methods")
   end
 
-  progress && @logmsg(-1,progress_name,_id=_id = :StochasticDiffEq,progress=0)
+  progress && @logmsg(LogLevel(-1),progress_name,_id=_id = :StochasticDiffEq,progress=0)
 
   tType = eltype(prob.tspan)
   noise = prob isa DiffEqBase.AbstractRODEProblem ? prob.noise : nothing


### PR DESCRIPTION
This change was necessary to get  `solve(SDEProblem(...),args...;kwargs..., progress=true)` to work. 
Before, this threw `MethodError: no method matching isless(::Int64, ::Base.CoreLogging.LogLevel)`