### PR TITLE
Com

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -130,7 +130,7 @@ module StochasticDiffEq
          DRI1, DRI1NM, RI1, RI3, RI5, RI6, RDI1WM, RDI2WM, RDI3WM, RDI4WM,
          RS1, RS2,
          PL1WM, PL1WMA,
-         NON
+         NON, COM
 
   export SIEA, SMEA, SIEB, SMEB    
 

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -83,6 +83,7 @@ alg_order(alg::PL1WM) = 1//1
 alg_order(alg::PL1WMA) = 1//1
 
 alg_order(alg::NON) = 1//1
+alg_order(alg::COM) = 1//1
 
 alg_order(alg::SIEA) = 1//1
 alg_order(alg::SMEA) = 1//1
@@ -117,6 +118,7 @@ alg_interpretation(alg::RS1) = :Stratonovich
 alg_interpretation(alg::RS2) = :Stratonovich
 
 alg_interpretation(alg::NON) = :Stratonovich
+alg_interpretation(alg::COM) = :Stratonovich
 
 alg_compatible(prob,alg::Union{StochasticDiffEqAlgorithm,StochasticDiffEqRODEAlgorithm}) = true
 alg_compatible(prob,alg::StochasticDiffEqAlgorithm) = false
@@ -154,6 +156,7 @@ alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::RS2) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WM) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WMA) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::NON) = true
+alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::COM) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SIEA) = is_diagonal_noise(prob)
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SMEA) = is_diagonal_noise(prob)
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SIEB) = is_diagonal_noise(prob)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -323,6 +323,14 @@ DOI:10.1016/j.cam.2006.06.006
 """
 struct NON <: StochasticDiffEqAlgorithm end
 
+"""
+Komori, Y., Weak order stochastic Runge–Kutta methods for commutative stochastic
+differential equations, Journal of Computational and Applied Mathematics 203,
+pp. 57 – 79 (2007)
+DOI:10.1016/j.cam.2006.03.010
+"""
+struct COM <: StochasticDiffEqAlgorithm end
+
 
 
 """

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1798,29 +1798,28 @@ function alg_cache(alg::COM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype
 end
 
 
-@cache struct COMCache{uType,randType,MType1,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
+@cache struct COMCache{uType,randType,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
   _dW::randType
-  Ihat2::MType1
 
   tab::tabType
 
   gtmp::rateNoiseType
   ktmp::rateType
 
-  Y100::uType
-  Y200::uType
-  Y300::uType
-  Y400::uType
-  Y1jajb::Array{uType}
-  Y2jajb::Array{uType}
-  Y3jajb::Array{uType}
-  Y4jajb::Array{uType}
+  Y10::uType
+  Y20::uType
+  Y30::uType
+  Y40::uType
+  Y1j::rateNoiseType
+  Y2j::rateNoiseType
+  Y3j::rateNoiseType
+  Y4j::rateNoiseType
 
   tmpu::uType
-  #tmpg::rateNoiseType
+  tmpu2::uType
 end
 
 
@@ -1833,24 +1832,24 @@ function alg_cache(alg::COM,prob,u,ΔW,ΔZ,p,rate_prototype,
     _dW = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = COMConstantCache(real(uBottomEltypeNoUnits))
 
   gtmp = zero(noise_rate_prototype)
   ktmp = zero(rate_prototype)
 
-  Y100 = zero(u)
-  Y200 = zero(u)
-  Y300 = zero(u)
-  Y400 = zero(u)
-  Y1jajb = [zero(u) for ja=1:m, jb=1:m]
-  Y2jajb = [zero(u) for ja=1:m, jb=1:m]
-  Y3jajb = [zero(u) for ja=1:m, jb=1:m]
-  Y4jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y10 = zero(u)
+  Y20 = zero(u)
+  Y30 = zero(u)
+  Y40 = zero(u)
+  Y1j = zero(noise_rate_prototype)
+  Y2j = zero(noise_rate_prototype)
+  Y3j = zero(noise_rate_prototype)
+  Y4j = zero(noise_rate_prototype)
 
   tmpu = zero(u)
+  tmpu2 = zero(u)
 
-  COMCache(u,uprev,_dW,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jajb,Y2jajb,Y3jajb,Y4jajb,tmpu)
+  COMCache(u,uprev,_dW,tab,gtmp,ktmp,Y10,Y20,Y30,Y40,Y1j,Y2j,Y3j,Y4j,tmpu,tmpu2)
 end
 
 

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1711,6 +1711,150 @@ end
 
 
 
+# COM
+struct COMConstantCache{T} <: StochasticDiffEqConstantCache
+  c01::T
+  c02::T
+  c03::T
+  c04::T
+
+  cj1::T
+  cj2::T
+  cj3::T
+  cj4::T
+
+  a0021::T
+  a0032::T
+  a0043::T
+
+  aj021::T
+  aj041::T
+
+  a0j21::T
+  a0j31::T
+  a0j32::T
+  a0j41::T
+
+  ajj21::T
+  ajj31::T
+  ajj32::T
+  ajj41::T
+  ajj42::T
+  ajj43::T
+
+  ajl31::T
+  ajl32::T
+  ajl41::T
+  ajl42::T
+
+  #quantile(Normal(),1/6)
+  NORMAL_ONESIX_QUANTILE::T
+end
+
+
+function COMConstantCache(T::Type)
+  c01 = convert(T, 1//6)
+  c02 = convert(T, 1//3)
+  c03 = convert(T, 1//3)
+  c04 = convert(T, 1//6)
+
+  cj1 = convert(T, 1//8)
+  cj2 = convert(T, 3//8)
+  cj3 = convert(T, 3//8)
+  cj4 = convert(T, 1//8)
+
+  a0021 = convert(T, 1//2)
+  a0032 = convert(T, 1//2)
+  a0043 = convert(T, 1)
+
+  aj021 = convert(T, 2)
+  aj041 = convert(T, -2)
+
+  a0j21 = convert(T, 1)
+  a0j31 = convert(T, -9//8)
+  a0j32 = convert(T, 9//8)
+  a0j41 = convert(T, 1)
+
+  ajj21 = convert(T, 2//3)
+  ajj31 = convert(T, 1//12)
+  ajj32 = convert(T, 1//4)
+  ajj41 = convert(T, -5//4)
+  ajj42 = convert(T, 1//4)
+  ajj43 = convert(T, 2)
+
+  ajl31 = convert(T, 1//4)
+  ajl32 = convert(T, 3//4)
+  ajl41 = convert(T, 1//4)
+  ajl42 = convert(T, 3//4)
+
+  NORMAL_ONESIX_QUANTILE = convert(T,-0.9674215661017014)
+
+  COMConstantCache(c01,c02,c03,c04,cj1,cj2,cj3,cj4,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,NORMAL_ONESIX_QUANTILE)
+end
+
+
+function alg_cache(alg::COM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
+  COMConstantCache(real(uBottomEltypeNoUnits))
+end
+
+
+@cache struct COMCache{uType,randType,MType1,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
+  u::uType
+  uprev::uType
+
+  _dW::randType
+  Ihat2::MType1
+
+  tab::tabType
+
+  gtmp::rateNoiseType
+  ktmp::rateType
+
+  Y100::uType
+  Y200::uType
+  Y300::uType
+  Y400::uType
+  Y1jajb::Array{uType}
+  Y2jajb::Array{uType}
+  Y3jajb::Array{uType}
+  Y4jajb::Array{uType}
+
+  tmpu::uType
+  #tmpg::rateNoiseType
+end
+
+
+function alg_cache(alg::COM,prob,u,ΔW,ΔZ,p,rate_prototype,
+                   noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,
+                   uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
+  if typeof(ΔW) <: Union{SArray,Number}
+    _dW = copy(ΔW)
+  else
+    _dW = zero(ΔW)
+  end
+  m = length(ΔW)
+  Ihat2 = zeros(eltype(ΔW), m, m)
+  tab = COMConstantCache(real(uBottomEltypeNoUnits))
+
+  gtmp = zero(noise_rate_prototype)
+  ktmp = zero(rate_prototype)
+
+  Y100 = zero(u)
+  Y200 = zero(u)
+  Y300 = zero(u)
+  Y400 = zero(u)
+  Y1jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y2jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y3jajb = [zero(u) for ja=1:m, jb=1:m]
+  Y4jajb = [zero(u) for ja=1:m, jb=1:m]
+
+  tmpu = zero(u)
+
+  COMCache(u,uprev,_dW,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jajb,Y2jajb,Y3jajb,Y4jajb,tmpu)
+end
+
+
+
 # SIE / SME methods
 
 struct SIESMEConstantCache{T,T2} <: StochasticDiffEqConstantCache

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -95,6 +95,20 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
+numtraj = Int(1e5)
+seed = 10
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3
+
+println("COM:", m)
+
+
 """
  Test Scalar SDEs (iip)
 """
@@ -157,6 +171,20 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON:", m)
+
+numtraj = Int(1e5)
+seed = 10
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3
+
+println("COM:", m)
+
 
 """
  Test non-commutative noise SDEs (iip)
@@ -226,6 +254,19 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
+numtraj = Int(5e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3 # tests are passing; problem might be not hard enough..
+
+println("COM:", m)
+
 
 """
  Test Diagonal noise SDEs (iip)
@@ -293,3 +334,17 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON:", m)
+
+
+numtraj = Int(6e4)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
+
+println("COM:", m)


### PR DESCRIPTION
This adds the `COM` scheme which is the commutative noise version of the NON scheme due to Komori (Refs are in issue #182 ).
A bit odd is that `COM` passes our non-commuting noise tests -- there is a related plot in their paper showing that one has to use  small values of dt to see a saturation. However, this would mean that we'd have to significantly increase the number of trajectories in the tests.

