### PR TITLE
NON2

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -130,9 +130,9 @@ module StochasticDiffEq
          DRI1, DRI1NM, RI1, RI3, RI5, RI6, RDI1WM, RDI2WM, RDI3WM, RDI4WM,
          RS1, RS2,
          PL1WM, PL1WMA,
-         NON, COM
+         NON, COM, NON2
 
-  export SIEA, SMEA, SIEB, SMEB    
+  export SIEA, SMEA, SIEB, SMEB
 
   export EulerHeun, LambaEulerHeun
 
@@ -162,6 +162,6 @@ module StochasticDiffEq
          constructDRI1, constructRI1, constructRI3, constructRI5, constructRI6,
          constructRDI1WM, constructRDI2WM, constructRDI3WM, constructRDI4WM,
          constructRS1, constructRS2,
-         constructNON
+         constructNON, constructNON2
 
 end # module

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -84,6 +84,7 @@ alg_order(alg::PL1WMA) = 1//1
 
 alg_order(alg::NON) = 1//1
 alg_order(alg::COM) = 1//1
+alg_order(alg::NON2) = 1//1
 
 alg_order(alg::SIEA) = 1//1
 alg_order(alg::SMEA) = 1//1
@@ -119,6 +120,7 @@ alg_interpretation(alg::RS2) = :Stratonovich
 
 alg_interpretation(alg::NON) = :Stratonovich
 alg_interpretation(alg::COM) = :Stratonovich
+alg_interpretation(alg::NON2) = :Stratonovich
 
 alg_compatible(prob,alg::Union{StochasticDiffEqAlgorithm,StochasticDiffEqRODEAlgorithm}) = true
 alg_compatible(prob,alg::StochasticDiffEqAlgorithm) = false
@@ -157,6 +159,7 @@ alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WM) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::PL1WMA) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::NON) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::COM) = true
+alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::NON2) = true
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SIEA) = is_diagonal_noise(prob)
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SMEA) = is_diagonal_noise(prob)
 alg_compatible(prob::DiffEqBase.AbstractSDEProblem,alg::SIEB) = is_diagonal_noise(prob)
@@ -225,6 +228,7 @@ alg_needs_extra_process(alg::RS1) = true
 alg_needs_extra_process(alg::RS2) = true
 alg_needs_extra_process(alg::PL1WM) = true
 alg_needs_extra_process(alg::NON) = true
+alg_needs_extra_process(alg::NON2) = true
 
 OrdinaryDiffEq.alg_autodiff(alg::StochasticDiffEqNewtonAlgorithm{CS,AD,Controller}) where {CS,AD,Controller} = AD
 OrdinaryDiffEq.alg_autodiff(alg::StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,Controller}) where {CS,AD,Controller} = AD

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -331,6 +331,13 @@ DOI:10.1016/j.cam.2006.03.010
 """
 struct COM <: StochasticDiffEqAlgorithm end
 
+"""
+Komori, Y., & Burrage, K. (2011). Supplement: Efficient weak second order stochastic
+Runge–Kutta methods for non-commutative Stratonovich stochastic differential equations.
+Journal of computational and applied mathematics, 235(17), pp. 5326 - 5329 (2011)
+DOI:10.1016/j.cam.2011.04.021 
+"""
+struct NON2 <: StochasticDiffEqAlgorithm end
 
 
 """

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1853,6 +1853,172 @@ function alg_cache(alg::COM,prob,u,ΔW,ΔZ,p,rate_prototype,
 end
 
 
+# NON2
+struct NON2ConstantCache{T} <: StochasticDiffEqConstantCache
+  c01::T
+  c02::T
+  c03::T
+  c04::T
+
+  cj1::T
+  cj2::T
+  cj3::T
+  cj4::T
+
+  a0021::T
+  a0032::T
+  a0043::T
+
+  aj021::T
+  aj041::T
+
+  a0j21::T
+  a0j31::T
+  a0j32::T
+  a0j41::T
+
+  ajj21::T
+  ajj31::T
+  ajj32::T
+  ajj41::T
+  ajj42::T
+  ajj43::T
+
+  ajl31::T
+  ajl32::T
+  ajl41::T
+  ajl42::T
+
+
+  # for non-commuting terms
+  #ckj3::T
+  #ckj4::T
+  #akjjl32::T
+  #akjjl42::T
+  # are all expressed in terms of γ
+  γ::T
+
+  #quantile(Normal(),1/6)
+  NORMAL_ONESIX_QUANTILE::T
+end
+
+
+function NON2ConstantCache(T::Type)
+  c01 = convert(T, 1//6)
+  c02 = convert(T, 1//3)
+  c03 = convert(T, 1//3)
+  c04 = convert(T, 1//6)
+
+  cj1 = convert(T, 1//8)
+  cj2 = convert(T, 3//8)
+  cj3 = convert(T, 3//8)
+  cj4 = convert(T, 1//8)
+
+  a0021 = convert(T, 1//2)
+  a0032 = convert(T, 1//2)
+  a0043 = convert(T, 1)
+
+  aj021 = convert(T, 2)
+  aj041 = convert(T, -2)
+
+  a0j21 = convert(T, 1)
+  a0j31 = convert(T, -9//8)
+  a0j32 = convert(T, 9//8)
+  a0j41 = convert(T, 1)
+
+  ajj21 = convert(T, 2//3)
+  ajj31 = convert(T, 1//12)
+  ajj32 = convert(T, 1//4)
+  ajj41 = convert(T, -5//4)
+  ajj42 = convert(T, 1//4)
+  ajj43 = convert(T, 2)
+
+  ajl31 = convert(T, 1//4)
+  ajl32 = convert(T, 3//4)
+  ajl41 = convert(T, 1//4)
+  ajl42 = convert(T, 3//4)
+
+  γ = convert(T, 1)
+
+  NORMAL_ONESIX_QUANTILE = convert(T,-0.9674215661017014)
+
+  NON2ConstantCache(c01,c02,c03,c04,cj1,cj2,cj3,cj4,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,γ,NORMAL_ONESIX_QUANTILE)
+end
+
+
+function alg_cache(alg::NON2,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
+  NON2ConstantCache(real(uBottomEltypeNoUnits))
+end
+
+
+@cache struct NON2Cache{uType,randType,MType1,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
+  u::uType
+  uprev::uType
+
+  _dW::randType
+  chi1::randType
+  Ihat2::MType1
+  tab::tabType
+
+  gtmp::rateNoiseType
+  gtmp1::rateNoiseType
+  ktmp::rateType
+
+  Y10::uType
+  Y20::uType
+  Y30::uType
+  Y40::uType
+  Y1j::rateNoiseType
+  Y2j::rateNoiseType
+  Y3j::rateNoiseType
+  Y4j::rateNoiseType
+
+  tmpu::uType
+  tmpu2::uType
+end
+
+
+function alg_cache(alg::NON2,prob,u,ΔW,ΔZ,p,rate_prototype,
+                   noise_rate_prototype,jump_rate_prototype,uEltypeNoUnits,
+                   uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
+  if typeof(ΔW) <: Union{SArray,Number}
+    _dW = copy(ΔW)
+    _dZ = copy(ΔW)
+    chi1 = copy(ΔW)
+  else
+    _dW = zero(ΔW)
+    _dZ = zero(ΔW)
+    chi1 = zero(ΔW)
+  end
+  m = length(ΔW)
+  Ihat2 = zeros(eltype(ΔW), m, m)
+  tab = COMConstantCache(real(uBottomEltypeNoUnits))
+
+  gtmp = zero(noise_rate_prototype)
+  gtmp1 = zero(noise_rate_prototype)
+  ktmp = zero(rate_prototype)
+
+  Y10 = zero(u)
+  Y20 = zero(u)
+  Y30 = zero(u)
+  Y40 = zero(u)
+  Y1j = zero(noise_rate_prototype)
+  Y2j = zero(noise_rate_prototype)
+  Y3j = zero(noise_rate_prototype)
+  Y4j = zero(noise_rate_prototype)
+
+  tmpu = zero(u)
+  tmpu2 = zero(u)
+
+  NON2Cache(u,uprev,_dW,chi1,Ihat2,tab,gtmp,gtmp1,ktmp,Y10,Y20,Y30,Y40,Y1j,Y2j,Y3j,Y4j,tmpu,tmpu2)
+end
+
+
+
+
+
+
+
 
 # SIE / SME methods
 

--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -1956,8 +1956,10 @@ end
   uprev::uType
 
   _dW::randType
+  _dZ::randType
   chi1::randType
   Ihat2::MType1
+
   tab::tabType
 
   gtmp::rateNoiseType
@@ -1992,7 +1994,7 @@ function alg_cache(alg::NON2,prob,u,ΔW,ΔZ,p,rate_prototype,
   end
   m = length(ΔW)
   Ihat2 = zeros(eltype(ΔW), m, m)
-  tab = COMConstantCache(real(uBottomEltypeNoUnits))
+  tab = NON2ConstantCache(real(uBottomEltypeNoUnits))
 
   gtmp = zero(noise_rate_prototype)
   gtmp1 = zero(noise_rate_prototype)
@@ -2010,7 +2012,7 @@ function alg_cache(alg::NON2,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmpu = zero(u)
   tmpu2 = zero(u)
 
-  NON2Cache(u,uprev,_dW,chi1,Ihat2,tab,gtmp,gtmp1,ktmp,Y10,Y20,Y30,Y40,Y1j,Y2j,Y3j,Y4j,tmpu,tmpu2)
+  NON2Cache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,gtmp,gtmp1,ktmp,Y10,Y20,Y30,Y40,Y1j,Y2j,Y3j,Y4j,tmpu,tmpu2)
 end
 
 

--- a/src/perform_step/srk_weak.jl
+++ b/src/perform_step/srk_weak.jl
@@ -1997,6 +1997,323 @@ end
 
 
 
+# NON2
+@muladd function perform_step!(integrator,cache::NON2ConstantCache,f=integrator.f)
+  @unpack c01,c02,c03,c04,cj1,cj2,cj3,cj4,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,γ,NORMAL_ONESIX_QUANTILE = cache
+  @unpack t,dt,uprev,u,W,p = integrator
+
+  m = length(W.dW)
+  _dW = W.dW
+
+  # define three-point distributed random variables
+  sq3dt = sqrt(3*dt)
+  chi1 = W.dW / integrator.sqdt
+  _dW = map(x -> calc_threepoint_random(sq3dt, NORMAL_ONESIX_QUANTILE, x), chi1)
+
+  if !(typeof(W.dW) <: Number)
+    # define two-point distributed random variables
+    _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x),  W.dZ)
+    Ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
+    for k = 1:m
+      for l = 1:k-1
+        Ihat2[k, l] = _dW[l]*_dZ[k]/integrator.sqdt
+        Ihat2[l, k] = -_dW[k]*_dZ[l]/integrator.sqdt
+      end
+    end
+  end
+  # compute stage values
+  # stage 1
+  ktmp = integrator.f(uprev,p,t)
+  gtmp = integrator.g(uprev,p,t)
+
+  Y10 = ktmp*dt
+
+  if typeof(W.dW) <: Number
+    Y1j = gtmp*_dW
+  else
+    if is_diagonal_noise(integrator.sol.prob)
+      Y1j = gtmp.*_dW
+    else
+      Y1j = gtmp.*_dW'
+    end
+  end
+
+  # stage 2
+  Y20 = uprev + a0021*Y10
+
+  if typeof(W.dW) <: Number
+    Y20 += a0j21*Y1j
+    Y2j = integrator.g(uprev + aj021*Y10 + ajj21*Y1j,p,t)*_dW
+  else
+    if !is_diagonal_noise(integrator.sol.prob)
+      Y2j = similar(integrator.sol.prob.noise_rate_prototype)
+      for j = 1:m
+        Y20 += a0j21*Y1j[:,j]
+        tmpu = uprev + aj021*Y10 + ajj21*Y1j[:,j]
+        Y2j[:,j] = integrator.g(tmpu,p,t)[:,j]*_dW[j]
+      end
+    else
+      Y20 += a0j21*Y1j
+      Y2j = similar(uprev)
+      for j = 1:m
+        tmpu = uprev + aj021*Y10
+        tmpu[j] += ajj21*Y1j[j]
+        Y2j[j] = integrator.g(tmpu,p,t)[j]*_dW[j]
+      end
+    end
+  end
+  ktmp = integrator.f(Y20,p,t)
+  Y20 = ktmp*dt
+
+  # stage 3
+  Y30 = uprev + a0032*Y20
+  if typeof(W.dW) <: Number
+    Y30 += a0j31*Y1j + a0j32*Y2j
+    Y3j = integrator.g(uprev + ajj31*Y1j + ajj32*Y2j,p,t)*_dW
+  else
+    if !is_diagonal_noise(integrator.sol.prob)
+      Y3j = similar(integrator.sol.prob.noise_rate_prototype)
+      for j = 1:m
+        tmpu = uprev + ajj31*Y1j[:,j] + ajj32*Y2j[:,j]
+        Y30 += a0j31*Y1j[:,j] + a0j32*Y2j[:,j]
+        for l = 1:m
+          if l!=j
+            tmpu += (ajl31*Y1j[:,l] + ajl32*Y2j[:,l])
+          end
+        end
+        Y3j[:,j] = integrator.g(tmpu,p,t)[:,j]*_dW[j]
+      end
+    else
+      Y30 += a0j31*Y1j + a0j32*Y2j
+      Y3j = similar(uprev)
+      tmpu2 = uprev + ajl31*Y1j + ajl32*Y2j
+      for j = 1:m
+        tmpu = copy(tmpu2)
+        tmpu[j] += ajj31*Y1j[j] + ajj32*Y2j[j] - (ajl31*Y1j[j] + ajl32*Y2j[j])
+        Y3j[j] = integrator.g(tmpu,p,t)[j]*_dW[j]
+      end
+    end
+  end
+  ktmp = integrator.f(Y30,p,t)
+  Y30 = ktmp*dt
+
+  # stage 4
+  Y40 = uprev + a0043*Y30
+  if typeof(W.dW) <: Number
+    Y40 += a0j41*Y1j
+    Y4j = integrator.g(uprev + ajj41*Y1j + ajj42*Y2j + ajj43*Y3j + aj041*Y10,p,t)*_dW
+  else
+    if !is_diagonal_noise(integrator.sol.prob)
+      Y4j = similar(integrator.sol.prob.noise_rate_prototype)
+      for j = 1:m
+        tmpu = uprev + ajj41*Y1j[:,j] + ajj42*Y2j[:,j] + ajj43*Y3j[:,j] + aj041*Y10
+        Y40 += a0j41*Y1j[:,j]
+        for l = 1:m
+          if l!=j
+            tmpu += (ajl41*Y1j[:,l] + ajl42*Y2j[:,l])
+          end
+        end
+        Y4j[:,j] = integrator.g(tmpu,p,t)[:,j]*_dW[j]
+    end
+    else
+      Y40 += a0j41*Y1j
+      Y4j = similar(uprev)
+      tmpu2 = uprev + ajl41*Y1j + ajl42*Y2j + aj041*Y10
+      for j = 1:m
+        tmpu = copy(tmpu2)
+        tmpu[j] += ajj41*Y1j[j] + ajj42*Y2j[j] + ajj43*Y3j[j] - (ajl41*Y1j[j] + ajl42*Y2j[j])
+        Y4j[j] = integrator.g(tmpu,p,t)[j]*_dW[j]
+      end
+    end
+  end
+  ktmp = integrator.f(Y40,p,t)
+  Y40 = ktmp*dt
+
+  # add stages together
+  u = uprev + c01*Y10+c02*Y20+c03*Y30+c04*Y40
+
+  if typeof(W.dW) <: Number
+    u += cj1*Y1j + cj2*Y2j + cj3*Y3j + cj4*Y4j
+  else
+    if is_diagonal_noise(integrator.sol.prob)
+      u += @. cj1*Y1j + cj2*Y2j + cj3*Y3j + cj4*Y4j
+    else
+      for j = 1:m
+        u += @. cj1*Y1j[:,j] + cj2*Y2j[:,j] + cj3*Y3j[:,j] + cj4*Y4j[:,j]
+        #add stage values for non-commutative processes
+      end
+    end
+  end
+  integrator.u = u
+end
+
+@muladd function perform_step!(integrator,cache::NON2Cache,f=integrator.f)
+  @unpack _dW,chi1,Ihat2,tab,gtmp,gtmp1,ktmp,Y10,Y20,Y30,Y40,Y1j,Y2j,Y3j,Y4j,tmpu,tmpu2 = cache
+  @unpack c01,c02,c03,c04,cj1,cj2,cj3,cj4,a0021,a0032,a0043,aj021,aj041,a0j21,a0j31,a0j32,a0j41,ajj21,ajj31,ajj32,ajj41,ajj42,ajj43,ajl31,ajl32,ajl41,ajl42,γ,NORMAL_ONESIX_QUANTILE = cache.tab
+  @unpack t,dt,uprev,u,W,p = integrator
+
+  m = length(W.dW)
+  @.. _dW =  W.dW
+
+  # define three-point distributed random variables
+  @.. chi1 = W.dW / integrator.sqdt
+  sq3dt = sqrt(3*dt)
+  calc_threepoint_random!(_dW, sq3dt, NORMAL_ONESIX_QUANTILE, chi1)
+
+  if !(typeof(W.dW) <: Number)
+    # define two-point distributed random variables
+    calc_twopoint_random!(_dZ,integrator.sqdt,W.dZ)
+    for k = 1:m
+      for l = 1:k-1
+       Ihat2[k, l] = _dW[l]*_dZ[k]/integrator.sqdt
+       Ihat2[l, k] = -_dW[k]*_dZ[l]/integrator.sqdt
+      end
+    end
+  end
+
+  # compute stage values
+  # stage 1
+  integrator.f(ktmp,uprev,p,t)
+  integrator.g(gtmp,uprev,p,t)
+
+  @.. Y10 = ktmp*dt
+
+
+  if is_diagonal_noise(integrator.sol.prob)
+    @.. Y1j = gtmp*_dW
+  else
+    for j = 1:m
+      Y1jj = @view Y1j[:,j]
+      gtmpj = @view gtmp[:,j]
+      @.. Y1jj = gtmpj*_dW[j]
+    end
+  end
+
+  # stage 2
+  @.. Y20 = uprev + a0021*Y10
+
+  if !is_diagonal_noise(integrator.sol.prob)
+    fill!(Y2j, zero(eltype(integrator.sol.prob.noise_rate_prototype)))
+    for j = 1:m
+      Y1jj = @view Y1j[:,j]
+      Y2jj = @view Y2j[:,j]
+      @.. Y20 = Y20 + a0j21*Y1jj
+      @.. tmpu = uprev + aj021*Y10 + ajj21*Y1jj
+      integrator.g(gtmp,tmpu,p,t)
+      gtmpj = @view gtmp[:,j]
+      @.. Y2jj = gtmpj*_dW[j]
+    end
+  else
+    fill!(Y2j, zero(eltype(integrator.u)))
+    @.. Y20 = Y20 + a0j21*Y1j
+    @.. tmpu = uprev + aj021*Y10
+    for j = 1:m
+      fill!(tmpu2,zero(eltype(integrator.u)))
+      tmpu2[j] = ajj21*Y1j[j]
+      @.. tmpu2 = tmpu + tmpu2
+      integrator.g(gtmp,tmpu2,p,t)
+      Y2j[j]= gtmp[j]*_dW[j]
+    end
+  end
+  integrator.f(ktmp,Y20,p,t)
+  @.. Y20 = ktmp*dt
+
+  # stage 3
+  @.. Y30 = uprev + a0032*Y20
+
+  if !is_diagonal_noise(integrator.sol.prob)
+    fill!(Y3j, zero(eltype(integrator.sol.prob.noise_rate_prototype)))
+    for j = 1:m
+      Y1jj = @view Y1j[:,j]
+      Y2jj = @view Y2j[:,j]
+      Y3jj = @view Y3j[:,j]
+      @.. tmpu = uprev + ajj31*Y1jj + ajj32*Y2jj
+      @.. Y30 = Y30 + a0j31*Y1jj + a0j32*Y2jj
+      for l = 1:m
+        if l!=j
+          Y1jl = @view Y1j[:,l]
+          Y2jl = @view Y2j[:,l]
+          @.. tmpu = tmpu + (ajl31*Y1jl + ajl32*Y2jl)
+        end
+      end
+      integrator.g(gtmp,tmpu,p,t)
+      gtmpj = @view gtmp[:,j]
+      @.. Y3jj = gtmpj*_dW[j]
+    end
+  else
+    @.. Y30 = Y30 + a0j31*Y1j + a0j32*Y2j
+    fill!(Y3j, zero(eltype(integrator.u)))
+    @.. tmpu2 = uprev + ajl31*Y1j + ajl32*Y2j
+    for j = 1:m
+      @.. tmpu = tmpu2
+      tmpu[j] += ajj31*Y1j[j] + ajj32*Y2j[j] - (ajl31*Y1j[j] + ajl32*Y2j[j])
+      integrator.g(gtmp,tmpu,p,t)
+      Y3j[j] = gtmp[j]*_dW[j]
+    end
+  end
+  integrator.f(ktmp,Y30,p,t)
+  @.. Y30 = ktmp*dt
+
+  # stage 4
+  @.. Y40 = uprev + a0043*Y30
+
+  if !is_diagonal_noise(integrator.sol.prob)
+    fill!(Y4j, zero(eltype(integrator.sol.prob.noise_rate_prototype)))
+    for j = 1:m
+      Y1jj = @view Y1j[:,j]
+      Y2jj = @view Y2j[:,j]
+      Y3jj = @view Y3j[:,j]
+      Y4jj = @view Y4j[:,j]
+      @.. tmpu = uprev + ajj41*Y1jj + ajj42*Y2jj + ajj43*Y3jj + aj041*Y10
+      @.. Y40 = Y40 + a0j41*Y1jj
+      for l = 1:m
+        if l!=j
+          Y1jl = @view Y1j[:,l]
+          Y2jl = @view Y2j[:,l]
+          @.. tmpu = tmpu + (ajl41*Y1jl + ajl42*Y2jl)
+        end
+      end
+      integrator.g(gtmp,tmpu,p,t)
+      gtmpj = @view gtmp[:,j]
+      @.. Y4jj = gtmpj*_dW[j]
+  end
+  else
+    @.. Y40 = Y40 + a0j41*Y1j
+    fill!(Y4j, zero(eltype(integrator.u)))
+    @.. tmpu2 = uprev + ajl41*Y1j + ajl42*Y2j + aj041*Y10
+    for j = 1:m
+      @.. tmpu = tmpu2
+      tmpu[j] += ajj41*Y1j[j] + ajj42*Y2j[j] + ajj43*Y3j[j] - (ajl41*Y1j[j] + ajl42*Y2j[j])
+      integrator.g(gtmp,tmpu,p,t)
+      Y4j[j] = gtmp[j]*_dW[j]
+    end
+  end
+  integrator.f(ktmp,Y40,p,t)
+  @.. Y40 = ktmp*dt
+
+  # add stages together
+  @.. u = uprev + c01*Y10+c02*Y20+c03*Y30+c04*Y40
+
+
+  if is_diagonal_noise(integrator.sol.prob)
+    @. u = u + cj1*Y1j + cj2*Y2j + cj3*Y3j + cj4*Y4j
+  else
+    for j = 1:m
+      Y1jj = @view Y1j[:,j]
+      Y2jj = @view Y2j[:,j]
+      Y3jj = @view Y3j[:,j]
+      Y4jj = @view Y4j[:,j]
+      @.. u = u + cj1*Y1jj + cj2*Y2jj + cj3*Y3jj + cj4*Y4jj
+
+      #add stage values for non-commutative processes
+    end
+  end
+end
+
+
+
+
+
 # SIE / SME
 @muladd function perform_step!(integrator,cache::SIESMEConstantCache,f=integrator.f)
   @unpack α1,α2,γ1,λ1,λ2,λ3,µ1,µ2,µ3,µ0,µbar0,λ0,λbar0,ν1,ν2,β2,β3,δ2,δ3 = cache

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,11 +88,12 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV,"APPVEYOR")
   end
 
   if !is_APPVEYOR && (GROUP == "All" || GROUP == "WeakConvergence4")
-      @time @safetestset "Roessler weak SRK Tests" begin include("weak_convergence/srk_weak_final_non_diagonal.jl") end
-      @time @safetestset "Weak Stratonovich Tests" begin include("weak_convergence/weak_strat.jl") end
+    @time @safetestset "Roessler weak SRK (non-diagonal) Tests" begin include("weak_convergence/srk_weak_final_non_diagonal.jl") end
+    @time @safetestset "Weak Stratonovich Tests" begin include("weak_convergence/weak_strat.jl") end
   end
 
   if !is_APPVEYOR && (GROUP == "All" || GROUP == "WeakConvergence5")
+    @time @safetestset "Weak Stratonovich (non-diagonal) Tests" begin include("weak_convergence/weak_strat_non_diagonal.jl") end
     @time @safetestset "SIE SME weak Tests" begin include("weak_convergence/SIE_SME.jl") end
   end
 

--- a/test/sde/sde_rosslerorder_tests.jl
+++ b/test/sde/sde_rosslerorder_tests.jl
@@ -42,3 +42,6 @@ RS2_tab = constructRS2()
 # Komori's NON
 NON_tab = constructNON()
 @test minimum(checkNONOrder(NON_tab))
+
+NON2_tab = constructNON2()
+@test minimum(checkNONOrder(NON2_tab))

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -95,6 +95,8 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
+dts = 1 .//2 .^(4:-1:0)
+
 numtraj = Int(1e5)
 seed = 10
 Random.seed!(seed)
@@ -103,21 +105,21 @@ seeds = rand(UInt, numtraj)
 _solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
-m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("COM:", m)
 
-
-numtraj = Int(1e5)
-seed = 10
+dts = 1 .//2 .^(5:-1:0)
+numtraj = Int(5e5)
+seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
 
 _solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
-m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON2:", m)
@@ -132,6 +134,7 @@ println("NON2:", m)
 f!(du,u,p,t) = du[1] = p[1]*u[1]
 g!(du,u,p,t) = du[1] = p[2]*u[1]
 
+numtraj = Int(1e5)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
@@ -186,6 +189,7 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 
 println("NON:", m)
 
+dts = 1 .//2 .^(4:-1:0)
 numtraj = Int(1e5)
 seed = 10
 Random.seed!(seed)
@@ -194,23 +198,25 @@ seeds = rand(UInt, numtraj)
 _solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
-m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("COM:", m)
 
-numtraj = Int(1e5)
-seed = 10
+dts = 1 .//2 .^(5:-1:0)
+numtraj = Int(5e5)
+seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
 
 _solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
 
 errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
-m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON2:", m)
+
 
 """
  Test Diagonal noise SDEs (iip)
@@ -266,7 +272,7 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 println("RS2:", m)
 
 
-numtraj = Int(1e6)
+numtraj = Int(1e5)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
@@ -278,7 +284,6 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("NON:", m)
-
 
 numtraj = Int(6e4)
 seed = 100
@@ -294,7 +299,7 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 println("COM:", m)
 
 
-numtraj = Int(6e4)
+numtraj = Int(1e5)
 seed = 100
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)

--- a/test/weak_convergence/weak_strat.jl
+++ b/test/weak_convergence/weak_strat.jl
@@ -2,7 +2,7 @@
  Tests for  https://link.springer.com/article/10.1007/s10543-007-0130-3 with test problems as in the paper.
  RS1, RS2
  and for https://www.sciencedirect.com/science/article/pii/S0377042706003906
- NON
+ NON, COM, NON2
 """
 
 
@@ -109,6 +109,20 @@ m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
 println("COM:", m)
 
 
+numtraj = Int(1e5)
+seed = 10
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3
+
+println("NON2:", m)
+
+
 """
  Test Scalar SDEs (iip)
 """
@@ -185,88 +199,18 @@ m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
 
 println("COM:", m)
 
-
-"""
- Test non-commutative noise SDEs (iip)
-"""
-
-@info "Non-commutative noise"
-
-u₀ = [0.1,0.1]
-function f2!(du,u,p,t)
-  du[1] = 5//4*u[2]-5//4*u[1]
-  du[2] = 1//4*u[1]-1//4*u[2]
-end
-function g2!(du,u,p,t)
-  du[1,1] = sqrt(3)/2*(u[1]-u[2])
-  du[1,2] = 1//2*(u[1]+u[2])
-  #du[2,1] = 0
-  du[2,2] = u[1]
-end
-dts = 1 .//2 .^(4:-1:1)
-tspan = (0.0,1.0)
-
-h2(z) = z^2 # E(x_i) = 1/10 exp(1/2t) or E(x_1* x_2) = 1/100 exp(2t)
-
-prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
-ensemble_prob = EnsembleProblem(prob;
-        output_func = (sol,i) -> (h2(sol[end][1]),false),
-        prob_func = prob_func
-        )
-
-numtraj = Int(1e6)
-seed = 100
+numtraj = Int(1e5)
+seed = 10
 Random.seed!(seed)
 seeds = rand(UInt, numtraj)
 
-_solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts, numtraj, ensemblealg=EnsembleThreads())
+_solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
 
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
-m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test abs(m-2) < 0.3
-
-println("RS1:", m)
-
-
-numtraj = Int(1e6)
-seed = 100
-Random.seed!(seed)
-seeds = rand(UInt, numtraj)
-
-_solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, ensemblealg=EnsembleThreads())
-
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
-m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test abs(m-2) < 0.3
-
-println("RS2:", m)
-
-numtraj = Int(1e6)
-seed = 100
-Random.seed!(seed)
-seeds = rand(UInt, numtraj)
-
-_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, ensemblealg=EnsembleThreads())
-
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
-m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
-@test abs(m-2) < 0.3
-
-println("NON:", m)
-
-numtraj = Int(5e5)
-seed = 100
-Random.seed!(seed)
-seeds = rand(UInt, numtraj)
-
-_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
-
-errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u) .- u₀.*exp(1.0*(p[1]+0.5*p[2]^2))) for sol in _solutions]
 m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
-@test abs(m-2) < 0.3 # tests are passing; problem might be not hard enough..
+@test abs(m-2) < 0.3
 
-println("COM:", m)
-
+println("NON2:", m)
 
 """
  Test Diagonal noise SDEs (iip)
@@ -348,3 +292,17 @@ m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
 @test abs(m-2) < 0.3
 
 println("COM:", m)
+
+
+numtraj = Int(6e4)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(301//100)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
+
+println("NON2:", m)

--- a/test/weak_convergence/weak_strat_non_diagonal.jl
+++ b/test/weak_convergence/weak_strat_non_diagonal.jl
@@ -1,0 +1,123 @@
+"""
+ Tests for  https://link.springer.com/article/10.1007/s10543-007-0130-3 with test problems as in the paper.
+ RS1, RS2
+ and for https://www.sciencedirect.com/science/article/pii/S0377042706003906
+ NON, COM, NON2
+"""
+
+
+import Statistics # for mean values of trajectories
+import LinearAlgebra # for the normn
+using StochasticDiffEq
+using Test
+using Random
+#using DiffEqGPU
+
+function generate_weak_solutions(prob, alg, dts, numtraj; ensemblealg=EnsembleThreads())
+  sols = []
+  for i in 1:length(dts)
+    sol = solve(prob,alg;ensemblealg=ensemblealg,dt=dts[i],adaptive=false,save_start=false,save_everystep=false,weak_timeseries_errors=false,weak_dense_errors=false,trajectories=Int(numtraj))
+    println(i)
+    push!(sols,sol)
+  end
+  return sols
+end
+
+function prob_func(prob, i, repeat)
+    remake(prob,seed=seeds[i])
+end
+
+"""
+ Test non-commutative noise SDEs (iip)
+"""
+
+@info "Non-commutative noise"
+
+u₀ = [0.1,0.1]
+function f2!(du,u,p,t)
+  du[1] = 5//4*u[2]-5//4*u[1]
+  du[2] = 1//4*u[1]-1//4*u[2]
+end
+function g2!(du,u,p,t)
+  du[1,1] = sqrt(3)/2*(u[1]-u[2])
+  du[1,2] = 1//2*(u[1]+u[2])
+  #du[2,1] = 0
+  du[2,2] = u[1]
+end
+dts = 1 .//2 .^(4:-1:1)
+tspan = (0.0,1.0)
+
+h2(z) = z^2 # E(x_i) = 1/10 exp(1/2t) or E(x_1* x_2) = 1/100 exp(2t)
+
+prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
+ensemble_prob = EnsembleProblem(prob;
+        output_func = (sol,i) -> (h2(sol[end][1]),false),
+        prob_func = prob_func
+        )
+
+numtraj = Int(1e6)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, RS1(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
+
+println("RS1:", m)
+
+
+numtraj = Int(1e6)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, RS2(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
+
+println("RS2:", m)
+
+numtraj = Int(1e6)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[1])/log(dts[end]/dts[1])
+@test abs(m-2) < 0.3
+
+println("NON:", m)
+
+numtraj = Int(5e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, COM(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3 # tests are passing; problem might be not hard enough..
+
+println("COM:", m)
+
+
+numtraj = Int(5e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+
+_solutions = @time generate_weak_solutions(ensemble_prob, NON2(), dts, numtraj, ensemblealg=EnsembleThreads())
+
+errors = [LinearAlgebra.norm(Statistics.mean(sol.u)-1//100*exp(2)) for sol in _solutions]
+m = log(errors[end]/errors[2])/log(dts[end]/dts[2])
+@test abs(m-2) < 0.3 # tests are passing; problem might be not hard enough..
+
+println("NON2:", m)


### PR DESCRIPTION
This adds the remaining solver NON2 due to Komori from issue https://github.com/SciML/StochasticDiffEq.jl/issues/182.

The diagonal stages are identical to COM. However, NON2 has two random processes and for non-diagonal noise processes the stage values Y3^(k(j),j) and Y4^(k(j),j) need to be computed.