### PR TITLE
Use heap initializations defined in OrdinaryDiffEq

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticDiffEq"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.26.0"
+version = "6.27.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -37,7 +37,7 @@ FiniteDiff = "2"
 ForwardDiff = "0.10.3"
 MuladdMacro = "0.2.1"
 NLsolve = "4"
-OrdinaryDiffEq = "5.38"
+OrdinaryDiffEq = "5.46"
 RandomNumbers = "1"
 RecursiveArrayTools = "2"
 Reexport = "0.2"

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -304,12 +304,10 @@ function DiffEqBase.reinit!(integrator::SDEIntegrator,u0 = integrator.sol.prob.u
   integrator.tprev = t0
 
   tType = typeof(integrator.t)
-  tstops_internal, saveat_internal, d_discontinuities_internal =
-    tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, (tType(t0), tType(tf)))
-
-  integrator.opts.tstops = tstops_internal
-  integrator.opts.saveat = saveat_internal
-  integrator.opts.d_discontinuities = d_discontinuities_internal
+  tspan = (tType(t0), tType(tf))
+  integrator.opts.tstops = OrdinaryDiffEq.initialize_tstops(tType, tstops, d_discontinuities, tspan)
+  integrator.opts.saveat = OrdinaryDiffEq.initialize_saveat(tType, saveat, tspan)
+  integrator.opts.d_discontinuities = OrdinaryDiffEq.initialize_d_discontinuities(tType, d_discontinuities, tspan)
 
   if erase_sol
     if integrator.opts.save_start


### PR DESCRIPTION
This PR removes the initialization methods for `tstops`, `saveat`, and `d_discontinuities` which were duplicates of the implementation in OrdinaryDiffEq and instead uses the new methods in OrdinaryDiffEq, introduced in https://github.com/SciML/OrdinaryDiffEq.jl/pull/1307.