### PR TITLE
Update CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,27 +1,16 @@
-
 name: CompatHelper
-
 on:
   schedule:
-    - cron: '00 * * * *'
-  issues:
-    types: [opened, reopened]
-
+    - cron: '00 00 * * *'
+  workflow_dispatch:
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  CompatHelper:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
CompatHelper configuration was outdated and could not trigger CI tests (see e.g. https://github.com/SciML/StochasticDiffEq.jl/pull/373). 