### PR TITLE
Fix interpolation permutation order

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -134,6 +134,11 @@ function sde_interpolation(tvals,id,idxs,deriv,p,continuity::Symbol=:left)
     end
   end
 
+  if tdir<0
+    reverse!(vals)
+    reverse!(tvals)
+  end
+
   DiffEqArray(vals, tvals)
 end
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -135,8 +135,8 @@ function sde_interpolation(tvals,id,idxs,deriv,p,continuity::Symbol=:left)
   end
 
   if tdir<0
-    reverse!(vals)
-    reverse!(tvals)
+    permute!(vals,idx)
+    permute!(tvals,idx)
   end
 
   DiffEqArray(vals, tvals)


### PR DESCRIPTION
By deleting https://github.com/SciML/StochasticDiffEq.jl/pull/361/files#diff-d62b3afef66e0202056f8ed75c1a19afbdb8005b1bcdfa6a10f822846a8fa459L140 we accidentally changed the direction of the interpolation's return because we were no longer directly updating an index but the indices could be in a different. This re-flips to fix that. 