### PR TITLE
Remove Ihat2 matrix from weak solvers

### DIFF
--- a/src/caches/srk_weak_caches.jl
+++ b/src/caches/srk_weak_caches.jl
@@ -514,7 +514,7 @@ function alg_cache(alg::RDI4WM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
   RDI4WMConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
 end
 
-@cache struct DRI1Cache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct DRI1Cache{uType,randType,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   uhat::uType
@@ -522,7 +522,6 @@ end
   _dW::randType
   _dZ::randType
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -549,14 +548,13 @@ end
 
 end
 
-@cache struct DRI1NMCache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct DRI1NMCache{uType,randType,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   uhat::uType
 
   _dW::randType
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -595,7 +593,6 @@ function alg_cache(alg::DRI1,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = DRI1ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -623,7 +620,7 @@ function alg_cache(alg::DRI1,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -639,7 +636,6 @@ function alg_cache(alg::DRI1NM,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = DRI1ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = zero(noise_rate_prototype)
@@ -660,7 +656,7 @@ function alg_cache(alg::DRI1NM,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1NMCache(u,uprev,uhat,_dW,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,tmp1,tmpg,tmp,resids)
+  DRI1NMCache(u,uprev,uhat,_dW,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -678,7 +674,6 @@ function alg_cache(alg::RI1,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RI1ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -706,7 +701,7 @@ function alg_cache(alg::RI1,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -724,7 +719,6 @@ function alg_cache(alg::RI3,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RI3ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -752,7 +746,7 @@ function alg_cache(alg::RI3,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -770,7 +764,6 @@ function alg_cache(alg::RI5,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RI5ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -798,7 +791,7 @@ function alg_cache(alg::RI5,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -816,7 +809,6 @@ function alg_cache(alg::RI6,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RI6ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -844,7 +836,7 @@ function alg_cache(alg::RI6,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -861,7 +853,6 @@ function alg_cache(alg::RDI2WM,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RDI2WMConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -889,7 +880,7 @@ function alg_cache(alg::RDI2WM,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -908,7 +899,6 @@ function alg_cache(alg::RDI3WM,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RDI3WMConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -936,7 +926,7 @@ function alg_cache(alg::RDI3WM,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -955,7 +945,6 @@ function alg_cache(alg::RDI4WM,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RDI4WMConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -983,7 +972,7 @@ function alg_cache(alg::RDI4WM,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp = zero(u)
   resids = zero(u)
 
-  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
+  DRI1Cache(u,uprev,uhat,_dW,_dZ,chi1,tab,g1,g2,g3,k1,k2,k3,H02,H03,H12,H13,H22,H23,tmp1,tmpg,tmp,resids)
 end
 
 
@@ -1056,14 +1045,12 @@ function alg_cache(alg::RDI1WM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
 end
 
 
-@cache struct RDI1WMCache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct RDI1WMCache{uType,randType,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
   _dW::randType
-  _dZ::randType
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -1083,15 +1070,12 @@ function alg_cache(alg::RDI1WM,prob,u,ΔW,ΔZ,p,rate_prototype,
                    uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
   if typeof(ΔW) <: Union{SArray,Number}
     _dW = copy(ΔW)
-    _dZ = copy(ΔW)
     chi1 = copy(ΔW)
   else
     _dW = zero(ΔW)
-    _dZ = zero(ΔW)
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RDI1WMConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   k1 = zero(rate_prototype); k2 = zero(rate_prototype)
@@ -1100,7 +1084,7 @@ function alg_cache(alg::RDI1WM,prob,u,ΔW,ΔZ,p,rate_prototype,
 
   tmp1 = zero(rate_prototype)
 
-  RDI1WMCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,k1,k2,H02,tmp1)
+  RDI1WMCache(u,uprev,_dW,chi1,tab,g1,k1,k2,H02,tmp1)
 end
 
 
@@ -1271,14 +1255,13 @@ function alg_cache(alg::RS2,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype
 end
 
 
-@cache struct RSCache{uType,randType,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct RSCache{uType,randType,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
   _dW::randType
   _dZ::randType
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -1317,7 +1300,6 @@ function alg_cache(alg::RS1,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RS1ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -1344,7 +1326,7 @@ function alg_cache(alg::RS1,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp1 = zero(rate_prototype)
   tmpg = zero(noise_rate_prototype)
 
-  RSCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,g4,k1,k2,k3,H02,H03,H12,H13,H14,H22,H23,tmp1,tmpg)
+  RSCache(u,uprev,_dW,_dZ,chi1,tab,g1,g2,g3,g4,k1,k2,k3,H02,H03,H12,H13,H14,H22,H23,tmp1,tmpg)
 end
 
 
@@ -1361,7 +1343,6 @@ function alg_cache(alg::RS2,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = RS2ConstantCache(real(uBottomEltypeNoUnits), real(tTypeNoUnits))
   g1 = zero(noise_rate_prototype)
   g2 = [zero(noise_rate_prototype) for k=1:m]
@@ -1388,7 +1369,7 @@ function alg_cache(alg::RS2,prob,u,ΔW,ΔZ,p,rate_prototype,
   tmp1 = zero(rate_prototype)
   tmpg = zero(noise_rate_prototype)
 
-  RSCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,g2,g3,g4,k1,k2,k3,H02,H03,H12,H13,H14,H22,H23,tmp1,tmpg)
+  RSCache(u,uprev,_dW,_dZ,chi1,tab,g1,g2,g3,g4,k1,k2,k3,H02,H03,H12,H13,H14,H22,H23,tmp1,tmpg)
 end
 
 
@@ -1425,14 +1406,13 @@ function alg_cache(alg::PL1WMA,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
 end
 
 
-@cache struct PL1WMCache{uType,randType,rand2Type,MType1,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
+@cache struct PL1WMCache{uType,randType,rand2Type,tabType,rateNoiseType,rateType,possibleRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
   _dW::randType
   _dZ::rand2Type
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -1465,7 +1445,6 @@ function alg_cache(alg::PL1WM,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = PL1WMConstantCache(real(uBottomEltypeNoUnits))
   g1 = zero(noise_rate_prototype)
 
@@ -1487,7 +1466,7 @@ function alg_cache(alg::PL1WM,prob,u,ΔW,ΔZ,p,rate_prototype,
   Ulp = zero(u)
   Ulm = zero(u)
 
-  PL1WMCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,g1,k1,k2,Y,Yp,Ym,tmp1,tmpg1,tmpg2,Ulp,Ulm)
+  PL1WMCache(u,uprev,_dW,_dZ,chi1,tab,g1,k1,k2,Y,Yp,Ym,tmp1,tmpg1,tmpg2,Ulp,Ulm)
 end
 
 
@@ -1646,14 +1625,13 @@ end
 
 
 
-@cache struct NONCache{uType,randType,MType1,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
+@cache struct NONCache{uType,randType,tabType,rateNoiseType,rateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
 
   _dW::randType
   _dZ::randType
   chi1::randType
-  Ihat2::MType1
 
   tab::tabType
 
@@ -1688,7 +1666,6 @@ function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,
     chi1 = zero(ΔW)
   end
   m = length(ΔW)
-  Ihat2 = zeros(eltype(ΔW), m, m)
   tab = NONConstantCache(real(uBottomEltypeNoUnits))
 
   gtmp = zero(noise_rate_prototype)
@@ -1705,7 +1682,7 @@ function alg_cache(alg::NON,prob,u,ΔW,ΔZ,p,rate_prototype,
 
   tmpu = zero(u)
 
-  NONCache(u,uprev,_dW,_dZ,chi1,Ihat2,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jajb,Y2jajb,Y3jajb,Y4jajb,tmpu)
+  NONCache(u,uprev,_dW,_dZ,chi1,tab,gtmp,ktmp,Y100,Y200,Y300,Y400,Y1jajb,Y2jajb,Y3jajb,Y4jajb,tmpu)
 
 end
 

--- a/src/perform_step/srk_weak.jl
+++ b/src/perform_step/srk_weak.jl
@@ -105,11 +105,11 @@
         u[k] +=  (m-1)*beta31*g1[k]*_dW[k]
         for l=1:m
           if l!=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
             tmpg = integrator.g(H22[l],p,t)
-            u[k] += tmpg[k]*(_dW[k]*beta32 +  Ihat2*beta42/integrator.sqdt)
+            u[k] += tmpg[k]*(_dW[k]*beta32 +  ihat2*beta42/integrator.sqdt)
             tmpg = integrator.g(H23[l],p,t)
-            u[k] += tmpg[k]*(_dW[k]*beta33 + Ihat2*beta43/integrator.sqdt)
+            u[k] += tmpg[k]*(_dW[k]*beta33 + ihat2*beta43/integrator.sqdt)
           end
         end
       end
@@ -124,13 +124,13 @@
         @.. u = u + g2k*chi1[k]*beta22/integrator.sqdt + g3k*chi1[k]*beta23/integrator.sqdt
         for l=1:m
           if l!=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
             tmpg = integrator.g(H22[l],p,t)
             tmpgk = @view tmpg[:,k]
-            @.. u = u + tmpgk*(_dW[k]*beta32 + Ihat2*beta42/integrator.sqdt)
+            @.. u = u + tmpgk*(_dW[k]*beta32 + ihat2*beta42/integrator.sqdt)
             tmpg = integrator.g(H23[l],p,t)
             tmpgk = @view tmpg[:,k]
-            @.. u = u + tmpgk*(_dW[k]*beta33 + Ihat2*beta43/integrator.sqdt)
+            @.. u = u + tmpgk*(_dW[k]*beta33 + ihat2*beta43/integrator.sqdt)
           end
         end
       end
@@ -260,11 +260,11 @@ end
         u[k] = u[k] + (m-1)*beta31*g1[k]*_dW[k]
         for l=1:m
           if l!=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
             integrator.g(tmpg,H22[l],p,t)
-            u[k] = u[k] + tmpg[k]*(_dW[k]*beta32 + Ihat2*beta42/integrator.sqdt)
+            u[k] = u[k] + tmpg[k]*(_dW[k]*beta32 + ihat2*beta42/integrator.sqdt)
             integrator.g(tmpg,H23[l],p,t)
-            u[k] = u[k] + tmpg[k]*(_dW[k]*beta33 + Ihat2*beta43/integrator.sqdt)
+            u[k] = u[k] + tmpg[k]*(_dW[k]*beta33 + ihat2*beta43/integrator.sqdt)
           end
         end
       end
@@ -280,11 +280,11 @@ end
       @.. u = u + g2k*chi1[k]*beta22/integrator.sqdt + g3k*chi1[k]*beta23/integrator.sqdt
       for l=1:m
         if l!=k
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
           integrator.g(tmpg,H22[l],p,t)
-          @.. u = u + tmpgk*(_dW[k]*beta32 + Ihat2*beta42/integrator.sqdt)
+          @.. u = u + tmpgk*(_dW[k]*beta32 + ihat2*beta42/integrator.sqdt)
           integrator.g(tmpg,H23[l],p,t)
-          @.. u = u + tmpgk*(_dW[k]*beta33 + Ihat2*beta43/integrator.sqdt)
+          @.. u = u + tmpgk*(_dW[k]*beta33 + ihat2*beta43/integrator.sqdt)
         end
       end
     end
@@ -660,13 +660,13 @@ end
         if k == l
           continue
         end
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
         if is_diagonal_noise(integrator.sol.prob)
-          @.. H22[k] += b221*g1[l]*Ihat2/integrator.sqdt
-          @.. H23[k] += b231*g1[l]*Ihat2/integrator.sqdt
+          @.. H22[k] += b221*g1[l]*ihat2/integrator.sqdt
+          @.. H23[k] += b231*g1[l]*ihat2/integrator.sqdt
         else
-          H22[k] += b221*g1[:,l]*Ihat2/integrator.sqdt
-          H23[k] += b231*g1[:,l]*Ihat2/integrator.sqdt
+          H22[k] += b221*g1[:,l]*ihat2/integrator.sqdt
+          H23[k] += b231*g1[:,l]*ihat2/integrator.sqdt
         end
       end
     end
@@ -856,14 +856,14 @@ end
         if k == l
           continue
         end
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, k, l)
         if is_diagonal_noise(integrator.sol.prob)
-          @.. H22[k] = H22[k] + b221*g1[l]*Ihat2/integrator.sqdt
-          @.. H23[k] = H23[k] + b231*g1[l]*Ihat2/integrator.sqdt
+          @.. H22[k] = H22[k] + b221*g1[l]*ihat2/integrator.sqdt
+          @.. H23[k] = H23[k] + b231*g1[l]*ihat2/integrator.sqdt
         else
           g1l = @view g1[:,l]
-          @.. H22[k] = H22[k] + b221*g1l*Ihat2/integrator.sqdt
-          @.. H23[k] = H23[k] + b231*g1l*Ihat2/integrator.sqdt
+          @.. H22[k] = H22[k] + b221*g1l*ihat2/integrator.sqdt
+          @.. H23[k] = H23[k] + b231*g1l*ihat2/integrator.sqdt
         end
       end
     end
@@ -963,7 +963,7 @@ end
         @.. u += (tmpg1[k]-tmpg2[k])*chi1[k]/integrator.sqdt
         for l=1:m
           if l!=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
 
             Ulp = @.. uprev + g1[l]*integrator.sqdt
             Ulm = @.. uprev - g1[l]*integrator.sqdt
@@ -971,7 +971,7 @@ end
             tmpg1 = integrator.g(Ulp,p,t)
             tmpg2 = integrator.g(Ulm,p,t)
             @.. u += 1//4*(tmpg1[k]+tmpg2[k]-2*g1[k])*_dW[k]
-            @.. u += 1//4*(tmpg1[k]-tmpg2[k])*(_dW[k]*_dW[l] + Ihat2)/integrator.sqdt
+            @.. u += 1//4*(tmpg1[k]-tmpg2[k])*(_dW[k]*_dW[l] + ihat2)/integrator.sqdt
           end
         end
       end
@@ -985,7 +985,7 @@ end
           u += (tmpg1[:,k]-tmpg2[:,k])*chi1[k]/integrator.sqdt
           for l=1:m
             if l!=k
-              Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
+              ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
 
               Ulp = uprev + g1[:,l]*integrator.sqdt
               Ulm = uprev - g1[:,l]*integrator.sqdt
@@ -993,7 +993,7 @@ end
               tmpg1 = integrator.g(Ulp,p,t)
               tmpg2 = integrator.g(Ulm,p,t)
               u += 1//4*(tmpg1[:,k]+tmpg2[:,k]-2*g1[:,k])*_dW[k]
-              u += 1//4*(tmpg1[:,k]-tmpg2[:,k])*(_dW[k]*_dW[l] + Ihat2)/integrator.sqdt
+              u += 1//4*(tmpg1[:,k]-tmpg2[:,k])*(_dW[k]*_dW[l] + ihat2)/integrator.sqdt
             end
           end
         end
@@ -1005,7 +1005,7 @@ end
 
 @muladd function perform_step!(integrator,cache::PL1WMCache)
   @unpack t,dt,uprev,u,W,p,f = integrator
-  @unpack _dW,_dZ,chi1,Ihat2,tab,g1,k1,k2,Y,Yp,Ym,tmp1,tmpg1,tmpg2,Ulp,Ulm = cache
+  @unpack _dW,_dZ,chi1,tab,g1,k1,k2,Y,Yp,Ym,tmp1,tmpg1,tmpg2,Ulp,Ulm = cache
   @unpack NORMAL_ONESIX_QUANTILE = cache.tab
 
   m = length(W.dW)
@@ -1067,7 +1067,7 @@ end
         @.. u = u + (tmpg1k-tmpg2k)*chi1[k]/integrator.sqdt
         for l=1:m
           if l !=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
 
             g1l = @view g1[:,l]
             @.. Ulp = uprev + g1l*integrator.sqdt
@@ -1078,7 +1078,7 @@ end
             tmpg1k = @view tmpg1[:,k]
             tmpg2k = @view tmpg2[:,k]
             u += 1//4*(tmpg1k+tmpg2k-2*g1k)*_dW[k]
-            u += 1//4*(tmpg1k-tmpg2k)*(_dW[k]*_dW[l] + Ihat2)/integrator.sqdt
+            u += 1//4*(tmpg1k-tmpg2k)*(_dW[k]*_dW[l] + ihat2)/integrator.sqdt
           end
         end
       end
@@ -1090,7 +1090,7 @@ end
         @.. u = u + (tmpg1[k]-tmpg2[k])*chi1[k]/integrator.sqdt
         for l=1:m
           if l !=k
-            Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
+            ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, l, k)
 
             @.. Ulp = uprev + g1[l]*integrator.sqdt
             @.. Ulm = uprev - g1[l]*integrator.sqdt
@@ -1098,7 +1098,7 @@ end
             integrator.g(tmpg1,Ulp,p,t)
             integrator.g(tmpg2,Ulm,p,t)
             @.. u = u + 1//4*(tmpg1[k]+tmpg2[k]-2*g1[k])*_dW[k]
-            @.. u = u + 1//4*(tmpg1[k]-tmpg2[k])*(_dW[k]*_dW[l] + Ihat2)/integrator.sqdt
+            @.. u = u + 1//4*(tmpg1[k]-tmpg2[k])*(_dW[k]*_dW[l] + ihat2)/integrator.sqdt
           end
         end
       end
@@ -1206,7 +1206,7 @@ end
   else
     for ja=1:m
       for jb=1:m
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
         if is_diagonal_noise(integrator.sol.prob)
           tmpu = zero(integrator.u)
           tmpu[jb] = gtmp[jb]
@@ -1247,7 +1247,7 @@ end
           end
           gtmp = integrator.g(tmpu,p,t)
           tmpjb = @view gtmp[:,jb]
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
           @.. Y2jajb[ja,jb] = Ihat2*tmpjb
         end
       end
@@ -1267,7 +1267,7 @@ end
           gtmp = integrator.g(tmpu,p,t)
           tmpu = zero(integrator.u)
           tmpu[jb] = gtmp[jb]
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
           @.. Y2jajb[ja,jb] = Ihat2*tmpu
         end
       end
@@ -1302,8 +1302,8 @@ end
           end
           gtmp = integrator.g(tmpu,p,t)
           tmpjb = @view gtmp[:,jb]
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-          @.. Y3jajb[ja,jb] = Ihat2*tmpjb
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+          @.. Y3jajb[ja,jb] = ihat2*tmpjb
         end
       end
     else
@@ -1327,8 +1327,8 @@ end
           gtmp = integrator.g(tmpu,p,t)
           tmpu = zero(integrator.u)
           tmpu[jb] = gtmp[jb]
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-          @.. Y3jajb[ja,jb] = Ihat2*tmpu
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+          @.. Y3jajb[ja,jb] = ihat2*tmpu
         end
       end
     end
@@ -1353,8 +1353,8 @@ end
         end
         gtmp = integrator.g(tmpu,p,t)
         tmpjb = @view gtmp[:,ja]
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
-        @.. Y4jajb[ja,ja] = Ihat2*tmpjb
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
+        @.. Y4jajb[ja,ja] = ihat2*tmpjb
       end
     else
       for ja=1:m
@@ -1369,8 +1369,8 @@ end
         gtmp = integrator.g(tmpu,p,t)
         tmpu = zero(integrator.u)
         tmpu[ja] = gtmp[ja]
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
-        @.. Y4jajb[ja,ja] = Ihat2*tmpu
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
+        @.. Y4jajb[ja,ja] = ihat2*tmpu
       end
     end
   end
@@ -1440,7 +1440,7 @@ end
   @.. Y100 = ktmp*dt
   for ja=1:m
     for jb=1:m
-      Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+      ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
       if is_diagonal_noise(integrator.sol.prob)
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
@@ -1476,7 +1476,7 @@ end
         end
         integrator.g(gtmp,tmpu,p,t)
         tmpjb = @view gtmp[:,jb]
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
         @.. Y2jajb[ja,jb] = Ihat2*tmpjb
         end
     end
@@ -1496,7 +1496,7 @@ end
         integrator.g(gtmp,tmpu,p,t)
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
         @.. Y2jajb[ja,jb] = Ihat2*tmpu
       end
     end
@@ -1527,7 +1527,7 @@ end
           end
           integrator.g(gtmp,tmpu,p,t)
           tmpjb = @view gtmp[:,jb]
-          Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+          ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
           @.. Y3jajb[ja,jb] = Ihat2*tmpjb
         end
       end
@@ -1552,7 +1552,7 @@ end
         integrator.g(gtmp,tmpu,p,t)
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
-        Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
+        ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
         @.. Y3jajb[ja,jb] = Ihat2*tmpu
       end
     end
@@ -1576,7 +1576,7 @@ end
       end
       integrator.g(gtmp,tmpu,p,t)
       tmpjb = @view gtmp[:,ja]
-      Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
+      ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
       @.. Y4jajb[ja,ja] = Ihat2*tmpjb
     end
   else
@@ -1592,7 +1592,7 @@ end
       integrator.g(gtmp,tmpu,p,t)
       fill!(tmpu,zero(eltype(integrator.u)))
       tmpu[ja] = gtmp[ja]
-      Ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
+      ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
       @.. Y4jajb[ja,ja] = Ihat2*tmpu
     end
   end
@@ -1946,7 +1946,7 @@ end
   if !(typeof(W.dW) <: Number)
     # define two-point distributed random variables
     _dZ = map(x -> calc_twopoint_random(integrator.sqdt, x),  W.dZ)
-    Ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
+    ihat2 = zeros(eltype(W.dZ), m, m) # I^_(k,l)
     for j = 1:m
       for l = 1:j-1
         Ihat2[j, l] = -_dZ[j]*_dW[l]/integrator.sqdt

--- a/src/perform_step/srk_weak.jl
+++ b/src/perform_step/srk_weak.jl
@@ -1444,15 +1444,15 @@ end
       if is_diagonal_noise(integrator.sol.prob)
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
-        @.. Y1jajb[ja,jb] = Ihat2*tmpu
+        @.. Y1jajb[ja,jb] = ihat2*tmpu
         if ja!=jb
-          @.. Y4jajb[ja,jb] = Ihat2*tmpu
+          @.. Y4jajb[ja,jb] = ihat2*tmpu
         end
       else
         gtmpjb = @view gtmp[:,jb]
-        @.. Y1jajb[ja,jb] = Ihat2*gtmpjb
+        @.. Y1jajb[ja,jb] = ihat2*gtmpjb
         if ja!=jb
-          @.. Y4jajb[ja,jb] = Ihat2*gtmpjb
+          @.. Y4jajb[ja,jb] = ihat2*gtmpjb
         end
       end
     end
@@ -1477,7 +1477,7 @@ end
         integrator.g(gtmp,tmpu,p,t)
         tmpjb = @view gtmp[:,jb]
         ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-        @.. Y2jajb[ja,jb] = Ihat2*tmpjb
+        @.. Y2jajb[ja,jb] = ihat2*tmpjb
         end
     end
   else
@@ -1497,7 +1497,7 @@ end
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
         ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-        @.. Y2jajb[ja,jb] = Ihat2*tmpu
+        @.. Y2jajb[ja,jb] = ihat2*tmpu
       end
     end
   end
@@ -1528,7 +1528,7 @@ end
           integrator.g(gtmp,tmpu,p,t)
           tmpjb = @view gtmp[:,jb]
           ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-          @.. Y3jajb[ja,jb] = Ihat2*tmpjb
+          @.. Y3jajb[ja,jb] = ihat2*tmpjb
         end
       end
   else
@@ -1553,7 +1553,7 @@ end
         fill!(tmpu,zero(eltype(integrator.u)))
         tmpu[jb] = gtmp[jb]
         ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, jb)
-        @.. Y3jajb[ja,jb] = Ihat2*tmpu
+        @.. Y3jajb[ja,jb] = ihat2*tmpu
       end
     end
   end
@@ -1577,7 +1577,7 @@ end
       integrator.g(gtmp,tmpu,p,t)
       tmpjb = @view gtmp[:,ja]
       ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
-      @.. Y4jajb[ja,ja] = Ihat2*tmpjb
+      @.. Y4jajb[ja,ja] = ihat2*tmpjb
     end
   else
     for ja=1:m
@@ -1593,7 +1593,7 @@ end
       fill!(tmpu,zero(eltype(integrator.u)))
       tmpu[ja] = gtmp[ja]
       ihat2 = Ihat2(cache, _dW, _dZ, integrator.sqdt, ja, ja)
-      @.. Y4jajb[ja,ja] = Ihat2*tmpu
+      @.. Y4jajb[ja,ja] = ihat2*tmpu
     end
   end
 

--- a/src/weak_utils.jl
+++ b/src/weak_utils.jl
@@ -18,3 +18,52 @@ end
 @muladd function calc_threepoint_random(sq3dt, quantile, dW_scaled)
   return ifelse(abs(dW_scaled) > -quantile, ifelse(dW_scaled < quantile, -sq3dt, sq3dt), zero(sq3dt))
 end
+
+function Ihat2(cache::Union{DRI1ConstantCache,DRI1Cache}, _dW, _dZ, sqdt, k, l)
+  # compute elements of I^_(k,l) which is a mxm matrix
+  if k<l
+    return (_dW[k]*_dW[l]-sqdt*_dZ[k])/2
+  elseif l<k
+    return (_dW[k]*_dW[l]+sqdt*_dZ[l])/2
+  else
+    # l == k
+    return (_dW[k]^2-sqdt^2)/2
+  end
+end
+
+function Ihat2(cache::Union{RSConstantCache,RSCache}, _dW, _dZ, sqdt, k, l)
+  # compute elements of I^_(k,l) which is a mxm matrix
+  if k<l
+    return -_dW[k]*_dZ[l]
+  elseif l<k
+    return _dW[k]*_dZ[l]
+  else
+    # l == k
+    return zero(_dW[k])
+  end
+end
+
+function Ihat2(cache::Union{PL1WMConstantCache,PL1WMCache}, _dW, _dZ, sqdt, k, l)
+  # compute elements of I^_(k,l) which is a mxm matrix
+  if k<l
+    return -_dZ[Int(1+1//2*(k-3)*k+l)]
+  elseif l<k
+    return _dZ[Int(1+1//2*(k-3)*k+l)]
+  else
+    # l == k
+    return -sqdt^2
+  end
+end
+
+
+function Ihat2(cache::Union{NONConstantCache,NONCache}, _dW, _dZ, sqdt, k, l)
+  # compute elements of I^_(k,l) which is a mxm matrix
+  if k<l
+    return _dZ[k]
+  elseif l<k
+    return _dW[l]
+  else
+    # l == k
+    return _dW[k]
+  end
+end

--- a/src/weak_utils.jl
+++ b/src/weak_utils.jl
@@ -46,7 +46,7 @@ end
 function Ihat2(cache::Union{PL1WMConstantCache,PL1WMCache}, _dW, _dZ, sqdt, k, l)
   # compute elements of I^_(k,l) which is a mxm matrix
   if k<l
-    return -_dZ[Int(1+1//2*(k-3)*k+l)]
+    return -_dZ[Int(1+1//2*(l-3)*l+k)]
   elseif l<k
     return _dZ[Int(1+1//2*(k-3)*k+l)]
   else

--- a/test/weak_convergence/PL1WM.jl
+++ b/test/weak_convergence/PL1WM.jl
@@ -178,7 +178,7 @@ sim = test_convergence(dts,ensemble_prob,PL1WM(),
     weak_timeseries_errors=false,weak_dense_errors=false,
     expected_value=1//100*exp(301//100)
     )
-@test abs(sim.𝒪est[:weak_final]-2) < 0.3
+@test abs(sim.𝒪est[:weak_final]-2) < 0.3 # order is 1.7612533343540109
 println("PL1WM:", sim.𝒪est[:weak_final])
 
 
@@ -210,7 +210,7 @@ sim = test_convergence(dts,ensemble_prob,PL1WM(),
     expected_value=u₀.*exp(1.0*(p[1]))
     )
 
-@test abs(sim.𝒪est[:weak_final]-2) < 0.3
+@test abs(sim.𝒪est[:weak_final]-2) < 0.3 # order is 1.9494776704064192
 println("PL1WM:", sim.𝒪est[:weak_final])
 
 sim1 = test_convergence(dts,ensemble_prob,PL1WMA(),
@@ -219,7 +219,7 @@ sim1 = test_convergence(dts,ensemble_prob,PL1WMA(),
     expected_value=u₀.*exp(1.0*(p[1]))
     )
 
-@test abs(sim1.𝒪est[:weak_final]-2) < 0.3
+@test abs(sim1.𝒪est[:weak_final]-2) < 0.3 # order is PL1WMA:1.9494776704064316
 println("PL1WMA:", sim1.𝒪est[:weak_final])
 
 @test minimum(sim.solutions .≈ sim1.solutions)
@@ -244,7 +244,7 @@ sim = test_convergence(dts,ensemble_prob,PL1WM(),
     expected_value=u₀.*exp(1.0*(p[1]))
 )
 
-@test abs(sim.𝒪est[:weak_final]-2) < 0.3
+@test abs(sim.𝒪est[:weak_final]-2) < 0.3 # order is 1.9494776704064192
 println("PL1WM:", sim.𝒪est[:weak_final])
 
 sim1 = test_convergence(dts,ensemble_prob,PL1WMA(),
@@ -253,7 +253,7 @@ sim1 = test_convergence(dts,ensemble_prob,PL1WMA(),
     expected_value=u₀.*exp(1.0*(p[1]))
     )
 
-@test abs(sim1.𝒪est[:weak_final]-2) < 0.3
+@test abs(sim1.𝒪est[:weak_final]-2) < 0.3 # order is 1.9494776704064316
 println("PL1WMA:", sim1.𝒪est[:weak_final])
 
 @test minimum(sim.solutions .≈ sim1.solutions)


### PR DESCRIPTION
see https://github.com/SciML/StochasticDiffEq.jl/issues/427 

`NON2` is the only method that doesn't exclusively access individual elements of the matrix `Ihat2` but instead it also contains matmuls of `g` with rows of `Ihat2`.  