### PR TITLE
Keep noise vectors dense

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "6.37.1"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -28,6 +29,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
+Adapt = "3"
 ArrayInterface = "2.4, 3.0"
 DataStructures = "0.18"
 DiffEqBase = "6.19"

--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -19,6 +19,7 @@ using DocStringExtensions
   using UnPack, RecursiveArrayTools, DataStructures
   using DiffEqNoiseProcess, Random, ArrayInterface
   using NLsolve, ForwardDiff, StaticArrays, MuladdMacro, FiniteDiff, Base.Threads
+  using Adapt
 
   import DiffEqBase: ODE_DEFAULT_NORM, ODE_DEFAULT_ISOUTOFDOMAIN,
          ODE_DEFAULT_PROG_MESSAGE, ODE_DEFAULT_UNSTABLE_CHECK

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -290,7 +290,7 @@ function DiffEqBase.__init(
         rand_prototype = (u .- u)./sqrt(oneunit(t))
       end
     elseif prob isa DiffEqBase.AbstractSDEProblem
-      rand_prototype = false .* noise_rate_prototype[1,:]
+      rand_prototype = adapt(DiffEqBase.parameterless_type(u),zeros(size(noise_rate_prototype,2)))
     elseif prob isa DiffEqBase.AbstractRODEProblem
       rand_prototype = copy(prob.rand_prototype)
     else


### PR DESCRIPTION
Previously we would create the noise vector via `noise_rate_prototype[1,:]`, which is the right size, but if the matrix is sparse that would be a sparse vector. This causes two issues. One is performance. The noise vector is always dense (since otherwise you would just make it smaller in the non-diagonal case), so using a sparse vector is just a bad idea. But secondly, it turns out that filling a sparse random vector that starts with 0 memory can lead to some undefined behavior, which causes the first random numbers to be truly random. Thus this performance fix is also fixes https://github.com/SciML/StochasticDiffEq.jl/issues/435, which I would thus say is the best of all worlds.