### PR TITLE
Move to `juliaecosystem`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - JuliaCI/julia-test#v1:
           coverage: false
     agents:
-      queue: "juliacpu"
+      queue: "juliaecosystem"
     env:
       GROUP: 'OOPWeakConvergence'
     timeout_in_minutes: 240
@@ -20,7 +20,7 @@ steps:
       - JuliaCI/julia-test#v1:
           coverage: false
     agents:
-      queue: "juliacpu"
+      queue: "juliaecosystem"
     env:
       GROUP: 'IIPWeakConvergence'
     timeout_in_minutes: 240
@@ -34,7 +34,7 @@ steps:
       - JuliaCI/julia-test#v1:
           coverage: false
     agents:
-      queue: "juliacpu"
+      queue: "juliaecosystem"
     env:
       GROUP: 'WeakAdaptiveCPU'
     timeout_in_minutes: 240

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ steps:
           coverage: false
     agents:
       queue: "juliaecosystem"
+      exclusive: true
     env:
       GROUP: 'OOPWeakConvergence'
     timeout_in_minutes: 240
@@ -21,6 +22,7 @@ steps:
           coverage: false
     agents:
       queue: "juliaecosystem"
+      exclusive: true
     env:
       GROUP: 'IIPWeakConvergence'
     timeout_in_minutes: 240


### PR DESCRIPTION
We don't have GPU runners on the sandbox runners yet, but we may eventually get them. Until then, we can continue to use `juliagpu`.