### PR TITLE
Enable multithreaded Julia on large tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ steps:
           version: "1"
       - JuliaCI/julia-test#v1:
           coverage: false
+          julia_args: "--threads=auto"
     agents:
       queue: "juliaecosystem"
       exclusive: true
@@ -20,6 +21,7 @@ steps:
           version: "1"
       - JuliaCI/julia-test#v1:
           coverage: false
+          julia_args: "--threads=auto"
     agents:
       queue: "juliaecosystem"
       exclusive: true


### PR DESCRIPTION
We need to explicitly tell Julia (when running the tests) to run with as many threads as the machine provides.