### PR TITLE
adaptive stepping `ISSEM` fixes

### DIFF
--- a/src/caches/implicit_split_step_caches.jl
+++ b/src/caches/implicit_split_step_caches.jl
@@ -6,33 +6,38 @@
   gtmp2::rateType
   nlsolver::N
   dW_cache::randType
+  k::uType
+  dz::uType
 end
 
-function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,
-                   ::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,f,t,dt,::Type{Val{true}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
-  γ, c = alg.theta,zero(t)
-  nlsolver = OrdinaryDiffEq.build_nlsolver(alg,u,uprev,p,t,dt,f,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,Val(true))
+function alg_cache(alg::ISSEM, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype, jump_rate_prototype,
+  ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{true}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+  γ, c = alg.theta, zero(t)
+  nlsolver = OrdinaryDiffEq.build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
   fsalfirst = zero(rate_prototype)
   gtmp = zero(noise_rate_prototype)
   if is_diagonal_noise(prob)
-    gtmp2 = gtmp
+    gtmp2 = copy(gtmp)
     dW_cache = nothing
   else
     gtmp2 = zero(rate_prototype)
     dW_cache = zero(ΔW)
   end
 
-  ISSEMCache(u,uprev,fsalfirst,gtmp,gtmp2,nlsolver,dW_cache)
+  k = zero(u)
+  dz = zero(u)
+
+  ISSEMCache(u, uprev, fsalfirst, gtmp, gtmp2, nlsolver, dW_cache, k, dz)
 end
 
 mutable struct ISSEMConstantCache{N} <: StochasticDiffEqConstantCache
   nlsolver::N
 end
 
-function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,
-                   ::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,f,t,dt,::Type{Val{false}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
-  γ, c = alg.theta,zero(t)
-  nlsolver = OrdinaryDiffEq.build_nlsolver(alg,u,uprev,p,t,dt,f,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,Val(false))
+function alg_cache(alg::ISSEM, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype, jump_rate_prototype,
+  ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{false}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+  γ, c = alg.theta, zero(t)
+  nlsolver = OrdinaryDiffEq.build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
   ISSEMConstantCache(nlsolver)
 end
 
@@ -45,35 +50,40 @@ end
   gtmp3::noiseRateType
   nlsolver::N
   dW_cache::randType
+  k::uType
+  dz::uType
 end
 
-function alg_cache(alg::ISSEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,
-                   ::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,f,t,dt,::Type{Val{true}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
-  γ, c = alg.theta,zero(t)
-  nlsolver = OrdinaryDiffEq.build_nlsolver(alg,u,uprev,p,t,dt,f,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,Val(true))
+function alg_cache(alg::ISSEulerHeun, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype, jump_rate_prototype,
+  ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{true}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+  γ, c = alg.theta, zero(t)
+  nlsolver = OrdinaryDiffEq.build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(true))
   fsalfirst = zero(rate_prototype)
 
   gtmp = zero(noise_rate_prototype)
   gtmp2 = zero(rate_prototype)
 
   if is_diagonal_noise(prob)
-      gtmp3 = gtmp2
-      dW_cache = nothing
+    gtmp3 = gtmp2
+    dW_cache = nothing
   else
-      gtmp3 = zero(noise_rate_prototype)
-      dW_cache = zero(ΔW)
+    gtmp3 = zero(noise_rate_prototype)
+    dW_cache = zero(ΔW)
   end
 
-  ISSEulerHeunCache(u,uprev,fsalfirst,gtmp,gtmp2,gtmp3,nlsolver,dW_cache)
+  k = zero(u)
+  dz = zero(u)
+
+  ISSEulerHeunCache(u, uprev, fsalfirst, gtmp, gtmp2, gtmp3, nlsolver, dW_cache, k, dz)
 end
 
 mutable struct ISSEulerHeunConstantCache{N} <: StochasticDiffEqConstantCache
   nlsolver::N
 end
 
-function alg_cache(alg::ISSEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,
-                   ::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,f,t,dt,::Type{Val{false}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
-  γ, c = alg.theta,zero(t)
-  nlsolver = OrdinaryDiffEq.build_nlsolver(alg,u,uprev,p,t,dt,f,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,γ,c,Val(false))
+function alg_cache(alg::ISSEulerHeun, prob, u, ΔW, ΔZ, p, rate_prototype, noise_rate_prototype, jump_rate_prototype,
+  ::Type{uEltypeNoUnits}, ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits}, uprev, f, t, dt, ::Type{Val{false}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+  γ, c = alg.theta, zero(t)
+  nlsolver = OrdinaryDiffEq.build_nlsolver(alg, u, uprev, p, t, dt, f, rate_prototype, uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits, γ, c, Val(false))
   ISSEulerHeunConstantCache(nlsolver)
 end

--- a/src/perform_step/implicit_split_step.jl
+++ b/src/perform_step/implicit_split_step.jl
@@ -58,7 +58,6 @@
     else
       J = OrdinaryDiffEq.calc_J(integrator, nlsolver.cache)
     end
-    du2 = integrator.f(uprev + dt * ftmp, p, t + dt)
     Ed = dt*(dt*J*ftmp)/2
 
     if typeof(cache) <: ISSEMConstantCache


### PR DESCRIPTION
Fixes the original issue https://github.com/SciML/StochasticDiffEq.jl/issues/481:
```
ERROR: UndefVarError: J not defined
```
for oop `SDEProblem`s. 

In addition, there were some inconsistencies in the adaptive sub-routine. 
for oop problems:
- There was a `dt` missing from the translation of https://github.com/SciML/StochasticDiffEq.jl/blob/b9806da512d1897cc5e8f9af37f4f15968d1f4cc/src/perform_step/lamba.jl#L23 to the Jacobian version.

for in-place problems:
- `tmp` (and some other variables) were changed before the use in the adaptive routine. Therefore, the stepping behavior did not agree with the oop version or the (similar) one from `LambdaEM`. I have now moved this part up. The variables `k` and `dz` have to be cached additionally in the alg cache. Otherwise, they are overwritten in the 
  ```julia
  z = OrdinaryDiffEq.nlsolve!(nlsolver, integrator, cache, repeat_step)  
  ```
  call.
- `gtmp2` and `gtmp` were identical because of the missing `copy` in the cache
