### PR TITLE
Remove unnecessary overload

### DIFF
--- a/src/perform_step/sdirk.jl
+++ b/src/perform_step/sdirk.jl
@@ -272,11 +272,3 @@ end
 
   end
 end
-
-### Mirror OrdinaryDiffEq because of dispatch on cache
-function OrdinaryDiffEq.update_W!(nlsolver::OrdinaryDiffEq.AbstractNLSolver, integrator, cache::StochasticDiffEqMutableCache, dtgamma, repeat_step)
-  if OrdinaryDiffEq.isnewton(nlsolver)
-    OrdinaryDiffEq.calc_W!(OrdinaryDiffEq.get_W(nlsolver), integrator, nlsolver, cache, dtgamma, repeat_step, true)
-  end
-  nothing
-end


### PR DESCRIPTION
Needs https://github.com/SciML/OrdinaryDiffEq.jl/pull/1698

@ChrisRackauckas how should we release this? OrdinaryDiffEq's downstream test won't pass because of this, while this alone would be broken.