### PR TITLE
avoid range allocation in SROCK step

### DIFF
--- a/src/perform_step/SROCK_perform_step.jl
+++ b/src/perform_step/SROCK_perform_step.jl
@@ -332,12 +332,8 @@ end
 
   sqrt_dt   = sqrt(abs(dt))
   if gen_prob
-    if hasfield(W, :rng)
-        rand!(W.rng, vec_χ)
-    else
-        rand!(vec_χ)
-    end
-    @.. vec_χ = 2*floor(vec_χ + 1//2) - 1
+    vec_χ .= 1//2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))
+    @.. vec_χ = 2*floor(vec_χ) - 1
   end
 
   μ = recf[start]  # here κ = 0

--- a/src/perform_step/SROCK_perform_step.jl
+++ b/src/perform_step/SROCK_perform_step.jl
@@ -332,8 +332,12 @@ end
 
   sqrt_dt   = sqrt(abs(dt))
   if gen_prob
-    vec_χ .= 1//2 .+ oftype(W.dW, rand(W.rng, length(W.dW)))
-    @.. vec_χ = 2*floor(vec_χ) - 1
+    if hasfield(W, :rng)
+        rand!(W.rng, vec_χ)
+    else
+        rand!(vec_χ)
+    end
+    @.. vec_χ = 2*floor(vec_χ + 1//2) - 1
   end
 
   μ = recf[start]  # here κ = 0

--- a/src/perform_step/SROCK_perform_step.jl
+++ b/src/perform_step/SROCK_perform_step.jl
@@ -426,10 +426,11 @@ end
       for i in 1:length(W.dW)
         WikJ = W.dW[i]; WikJ2 = vec_χ[i]
         dwrange = 1:length(W.dW)
-        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs(dt))#.+ (1:length(W.dW) .< i) .* dt .* WikJ2 .- (1:length(W.dW) .> i) .* dt .* vec_χ)
+        abs_dt = abs(dt)
+        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs_dt) #+ (dwrange < i) * dt * WikJ2 - (dwrange > i) * dt * vec_χ)
         mul!(uₓ,Gₛ,WikRange)
         @.. uᵢ₋₂ = uᵢ + uₓ
-        WikRange .= 1//2 .* (1:length(W.dW) .== i)
+        @.. WikRange = 1//2 * (dwrange == i)
         integrator.g(Gₛ₁,uᵢ₋₂,p,tᵢ)
         mul!(uᵢ₋₂,Gₛ₁,WikRange)
         @.. u   += uᵢ₋₂
@@ -621,9 +622,10 @@ end
       for i in 1:length(W.dW)
         WikJ = W.dW[i]
         dwrange = 1:length(W.dW)
-        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs(dt))
+        abs_dt = abs(dt)
+        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs_dt)
         mul!(uᵢ₋₂,Gₛ,WikRange)
-        WikRange .= 1//2 .* (1:length(W.dW) .== i)
+        @.. WikRange = 1//2 * (dwrange == i)
         @.. tmp = u + uᵢ₋₂
         integrator.g(Gₛ₁,tmp,p,tᵢ)
         mul!(uᵢ₋₁,Gₛ₁,WikRange)

--- a/src/perform_step/SROCK_perform_step.jl
+++ b/src/perform_step/SROCK_perform_step.jl
@@ -425,7 +425,8 @@ end
 
       for i in 1:length(W.dW)
         WikJ = W.dW[i]; WikJ2 = vec_χ[i]
-        WikRange .= 1//2 .* (W.dW .* WikJ .- (1:length(W.dW) .== i) .* abs(dt) )#.+ (1:length(W.dW) .< i) .* dt .* WikJ2 .- (1:length(W.dW) .> i) .* dt .* vec_χ)
+        dwrange = 1:length(W.dW)
+        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs(dt))#.+ (1:length(W.dW) .< i) .* dt .* WikJ2 .- (1:length(W.dW) .> i) .* dt .* vec_χ)
         mul!(uₓ,Gₛ,WikRange)
         @.. uᵢ₋₂ = uᵢ + uₓ
         WikRange .= 1//2 .* (1:length(W.dW) .== i)
@@ -619,7 +620,8 @@ end
     else
       for i in 1:length(W.dW)
         WikJ = W.dW[i]
-        WikRange .= 1//2 .* (WikJ .* W.dW .- (1:length(W.dW) .== i) .* abs(dt))
+        dwrange = 1:length(W.dW)
+        @.. WikRange = 1//2 * (W.dW * WikJ - (dwrange == i) * abs(dt))
         mul!(uᵢ₋₂,Gₛ,WikRange)
         WikRange .= 1//2 .* (1:length(W.dW) .== i)
         @.. tmp = u + uᵢ₋₂


### PR DESCRIPTION
fixes #478
note there is still 2 similar lines for the constant cached versions, which don't use inplace assignment. I don't know if the change is necessary there too.