### PR TITLE
Use copy for noise

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -413,7 +413,7 @@ function DiffEqBase.__init(
       =#
     end
   elseif typeof(prob) <: DiffEqBase.AbstractRODEProblem
-    W = (!haskey(kwargs, :alias_noise) || kwargs[:alias_noise] === true) ? deepcopy(prob.noise) : prob.noise
+    W = (!haskey(kwargs, :alias_noise) || kwargs[:alias_noise] === true) ? copy(prob.noise) : prob.noise
     if W.reset
       # Reseed
       if typeof(W) <: Union{NoiseProcess, NoiseTransport} && W.reseed

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -6,10 +6,7 @@ function DiffEqBase.__solve(prob::DiffEqBase.AbstractRODEProblem,
   integrator = DiffEqBase.__init(prob,alg,timeseries,ts,recompile;kwargs...)
   solve!(integrator)
   if typeof(prob) <: DiffEqBase.AbstractRODEProblem && typeof(prob.noise) == typeof(integrator.sol.W) && (!haskey(kwargs, :alias_noise) || kwargs[:alias_noise] === true)
-    # would be better to make the following a function `noise_deepcopy!(W::T, Z::T) where {T <: AbstractNoiseProcess}` in `DiffEqNoiseProcess.jl` or a proper `copy` overload, but this should do it for the moment
-    for x in fieldnames(typeof(prob.noise))
-        setfield!(prob.noise, x, deepcopy(getfield(integrator.sol.W, x)))
-    end
+    copy!(prob.noise, integrator.sol.W)
   end
   integrator.sol
 end

--- a/test/noise_type_test.jl
+++ b/test/noise_type_test.jl
@@ -46,16 +46,19 @@ sol = solve(prob,EM(),dt=1/100)
 
 @test sol.W == prob.noise
 @test objectid(prob.noise) != objectid(sol.W)
+@test objectid(prob.noise.u) == objectid(prob.noise.W) != objectid(sol.W.W) == objectid(sol.W.u)
 
 sol = solve(prob,EM(),dt=1/1000,alias_noise=false)
 
 @test sol.W == prob.noise
 @test objectid(prob.noise) == objectid(sol.W)
+@test objectid(prob.noise.u) == objectid(prob.noise.W) == objectid(sol.W.W) == objectid(sol.W.u)
 
 sol = solve(prob,EM(),dt=1/1000, alias_noise=true)
 
 @test sol.W == prob.noise
 @test objectid(prob.noise) != objectid(sol.W)
+@test objectid(prob.noise.u) == objectid(prob.noise.W) != objectid(sol.W.W) == objectid(sol.W.u)
 
 function g(du,u,p,t)
   @test typeof(du) <: SparseMatrixCSC
@@ -95,6 +98,9 @@ sol = solve(prob,EM(),dt=0.01)
 
 @test typeof(sol.W) == typeof(prob.noise) <: NoiseFunction
 @test objectid(prob.noise) != objectid(sol.W)
+
+sol = solve(prob,EM(),dt=1/1000,alias_noise=false)
+@test objectid(prob.noise) == objectid(sol.W)
 
 sol = solve(prob,EM(),dt=0.01,alias_noise=true)
 @test sol.W.curt ≈ last(tspan)


### PR DESCRIPTION
This uses `copy` and `copy!` from the new PR https://github.com/SciML/DiffEqNoiseProcess.jl/pull/127 instead of `deepcopy`, when solving an `AbstractRODEProblem`. 