### PR TITLE
remove gamma param from noise term for BAOAB alg

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -866,5 +866,6 @@ dv = f(v,u) dt - \gamma v dt + g(u) \sqrt{2\gamma} dW
 """
 struct BAOAB{T} <: StochasticDiffEqAlgorithm
   gamma::T
+  scale_noise::Bool
 end
-BAOAB(;gamma=1.0) = BAOAB(gamma)
+BAOAB(;gamma=1.0, scale_noise=true) = BAOAB(gamma, scale_noise)

--- a/src/caches/dynamical_caches.jl
+++ b/src/caches/dynamical_caches.jl
@@ -20,7 +20,7 @@ end
 function alg_cache(alg::BAOAB,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,jump_rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,f,t,dt,::Type{Val{false}}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
   k = zero(rate_prototype.x[1])
   c1 = exp(-alg.gamma*dt)
-  c2 = sqrt(1 - c1^2)
+  c2 = sqrt(1 - alg.scale_noise*c1^2) # if scale_noise == false, c2 = 1
   BAOABConstantCache(k, uEltypeNoUnits(1//2), uEltypeNoUnits(c1), uEltypeNoUnits(c2))
 end
 
@@ -34,7 +34,7 @@ function alg_cache(alg::BAOAB,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototy
 
   half = uEltypeNoUnits(1//2)
   c1 = exp(-alg.gamma*dt)
-  c2 = sqrt(1 - c1^2)
+  c2 = sqrt(1 - alg.scale_noise*c1^2) # if scale_noise == false, c2 = 1
 
   tmp = zero(u)
 


### PR DESCRIPTION
As discussed in #519, I want to experiment with removing the `gamma` dependence attached to the noise term for the `BAOAB` algorithm.

The main issue is that if you do want the `gamma` dependence, you also need a dependence on `dt` (coming from the `c1` variable in the original code). While this `dt` dependence could be user-coded in the `g` noise function, it's not an ideal interface.

Suggestions welcome.