### PR TITLE
rm unused DiffEqOperators test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,7 +57,6 @@ julia = "1.6"
 [extras]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
-DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -68,4 +67,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "SDEProblemLibrary", "LinearSolve", "ModelingToolkit", "Pkg", "SafeTestsets", "SparseArrays", "Statistics", "Test"]
+test = ["DiffEqCallbacks", "DiffEqDevTools", "SDEProblemLibrary", "LinearSolve", "ModelingToolkit", "Pkg", "SafeTestsets", "SparseArrays", "Statistics", "Test"]


### PR DESCRIPTION
```shell
StochasticDiffEq.jl on  master is 📦 v6.57.4 via ஃ v1.8.5 
❯ grep -IRni diffeqop
./Project.toml:60:DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
./Project.toml:71:test = ["DiffEqCallbacks", "DiffEqDevTools", "DiffEqOperators", "SDEProblemLibrary", "LinearSolve", "ModelingToolkit", "Pkg", "SafeTestsets", "SparseArrays", "Statistics", "Test"]
```