### PR TITLE
import AbstractController from OrdinaryDiffEq.jl

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -14,7 +14,7 @@ using DocStringExtensions
          beta2_default, beta1_default, gamma_default,
          qmin_default, qmax_default, qsteady_min_default, qsteady_max_default,
          stepsize_controller!, accept_step_controller, step_accept_controller!,
-         step_reject_controller!, PIController, DummyController
+         step_reject_controller!, PIController, DummyController, AbstractController
 
   using UnPack, RecursiveArrayTools, DataStructures
   using DiffEqNoiseProcess, Random, ArrayInterface

--- a/src/integrators/stepsize_controllers.jl
+++ b/src/integrators/stepsize_controllers.jl
@@ -3,18 +3,22 @@ function stepsize_controller!(integrator::SDEIntegrator, controller::PIControlle
     integrator.q11 = DiffEqBase.value(DiffEqBase.fastpow(integrator.EEst,controller.beta1))
     integrator.q = DiffEqBase.value(integrator.q11/DiffEqBase.fastpow(integrator.qold,controller.beta2))
     @fastmath integrator.q = DiffEqBase.value(max(inv(integrator.opts.qmax),min(inv(integrator.opts.qmin),integrator.q/integrator.opts.gamma)))
+    nothing
 end
 
 @inline function step_accept_controller!(integrator::SDEIntegrator, alg)
     step_accept_controller!(integrator, integrator.opts.controller, alg)
+    nothing
 end
 
 function step_accept_controller!(integrator::SDEIntegrator, controller::PIController, alg)
     integrator.dtnew = DiffEqBase.value(integrator.dt/integrator.q) * oneunit(integrator.dt)
+    nothing
 end
 
 function step_reject_controller!(integrator::SDEIntegrator, controller::PIController, alg)
     integrator.dtnew = integrator.dt/min(inv(integrator.opts.qmin),integrator.q11/integrator.opts.gamma)
+    nothing
 end
 
 
@@ -29,6 +33,7 @@ end
 
 function step_reject_controller!(integrator::SDEIntegrator, alg::TauLeaping)
     integrator.dt = integrator.opts.gamma * integrator.dt / integrator.EEst
+    nothing
 end
 
 


### PR DESCRIPTION
If Controllers should subtype `StochasticDiffEq.AbstractController` this will allow us to implement custom adaptive schemes easily.

```julia
struct CustomController <: StochasticDiffEq.AbstractController
end

function StochasticDiffEq.stepsize_controller!(integrator::StochasticDiffEq.SDEIntegrator, controller::CustomController, alg)
    u = integrator.u
    integrator.q = max(...)
    nothing
end

function StochasticDiffEq.step_accept_controller!(integrator::StochasticDiffEq.SDEIntegrator, controller::CustomController, alg)
    integrator.dtnew = 1 / integrator.q * oneunit(integrator.dt)
    nothing
end

sol = solve(prob, EM(), dt=dt, adaptive=true, controller=CustomController())
```