### PR TITLE
Fix downstream DiffEqNoiseProcess test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: StochasticDelayDiffEq.jl, group: All}
-          - {user: SciML, repo: DiffEqNoiseProcess.jl, group: All}
+          - {user: SciML, repo: DiffEqNoiseProcess.jl, group: Core1}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The bridge tests got a lot more intense and so they are in a separate group that requires the better machines. Just lop them off the downstream.