### PR TITLE
refactor: remove redundant `getproperty` method

### DIFF
--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -44,12 +44,3 @@ mutable struct SDEIntegrator{algType,IIP,uType,uEltype,tType,tdirType,P2,eigenTy
   q11::tTypeNoUnits
   stats::DiffEqBase.Stats
 end
-
-function Base.getproperty(integ::SDEIntegrator, s::Symbol)
-    if s === :destats
-        @warn "destats has been deprecated for stats"
-        getfield(integ,:stats)
-    else
-        getfield(integ,s)
-    end
-end


### PR DESCRIPTION
Implemented in SciMLBase

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
