### PR TITLE
remove precs

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -141,7 +141,7 @@ SciMLBase.alg_interpretation(alg::RKMil{interpretation}) where {interpretation} 
 SciMLBase.alg_interpretation(alg::SROCK1{interpretation,E}) where {interpretation,E} = interpretation
 SciMLBase.alg_interpretation(alg::RKMilCommute) = alg.interpretation
 SciMLBase.alg_interpretation(alg::RKMilGeneral) = alg.interpretation
-SciMLBase.alg_interpretation(alg::ImplicitRKMil{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller,interpretation}) where {CS,AD,F,P,FDT,ST,CJ,N,T2,Controller,interpretation} = interpretation
+SciMLBase.alg_interpretation(alg::ImplicitRKMil{CS,AD,F,FDT,ST,CJ,N,T2,Controller,interpretation}) where {CS,AD,F,FDT,ST,CJ,N,T2,Controller,interpretation} = interpretation
 
 SciMLBase.alg_interpretation(alg::RS1) = :Stratonovich
 SciMLBase.alg_interpretation(alg::RS2) = :Stratonovich

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -634,10 +634,9 @@ This is a theta method which defaults to theta=1 or the Trapezoid method on the 
 This method defaults to symplectic=false, but when true and theta=1/2 this is the implicit Midpoint method on the drift term and is symplectic in distribution.
 Can handle all forms of noise, including non-diagonal, scalar, and colored noise. Uses a 1.0/1.5 heuristic for adaptive time stepping.
 """
-struct ImplicitEM{CS,AD,F,F2,P,FDT,ST,CJ,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct ImplicitEM{CS,AD,F,F2,FDT,ST,CJ,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
   linsolve::F
   nlsolve::F2
-  precs::P
   theta::T2
   extrapolant::Symbol
   new_jac_conv_bound::T2
@@ -645,18 +644,17 @@ struct ImplicitEM{CS,AD,F,F2,P,FDT,ST,CJ,T2,Controller} <: StochasticDiffEqNewto
 end
 ImplicitEM(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                           standardtag = Val{true}(),concrete_jac = nothing,
-                          precs = OrdinaryDiffEq.DEFAULT_PRECS,
                           linsolve=nothing,nlsolve=NLNewton(),
                           extrapolant=:constant,
                           theta = 1,symplectic=false,
                           new_jac_conv_bound = 1e-3,
                           controller = :Predictive) =
                           ImplicitEM{chunk_size,autodiff,
-                          typeof(linsolve),typeof(nlsolve),typeof(precs),diff_type,
+                          typeof(linsolve),typeof(nlsolve),diff_type,
                           OrdinaryDiffEq._unwrap_val(standardtag),
                           OrdinaryDiffEq._unwrap_val(concrete_jac),
                           typeof(new_jac_conv_bound),controller}(
-                          linsolve,nlsolve,precs,
+                          linsolve,nlsolve,
                           symplectic ? 1/2 : theta,
                           extrapolant,new_jac_conv_bound,symplectic)
 
@@ -669,10 +667,9 @@ This is a theta method which defaults to theta=1/2 or the Trapezoid method on th
 This method defaults to symplectic=false, but when true and theta=1 this is the implicit Midpoint method on the drift term and is symplectic in distribution.
 Can handle all forms of noise, including non-diagonal, scalar, and colored noise. Uses a 1.0/1.5 heuristic for adaptive time stepping.
 """
-struct ImplicitEulerHeun{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct ImplicitEulerHeun{CS,AD,F,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
   linsolve::F
   nlsolve::N
-  precs::P
   theta::T2
   extrapolant::Symbol
   new_jac_conv_bound::T2
@@ -680,19 +677,18 @@ struct ImplicitEulerHeun{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffE
 end
 ImplicitEulerHeun(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                           standardtag = Val{true}(),concrete_jac = nothing,
-                          precs = OrdinaryDiffEq.DEFAULT_PRECS,
                           linsolve=nothing,nlsolve=NLNewton(),
                           extrapolant=:constant,
                           theta = 1,symplectic = false,
                           new_jac_conv_bound = 1e-3,
                           controller = :Predictive) =
                           ImplicitEulerHeun{chunk_size,autodiff,
-                          typeof(linsolve),typeof(precs),diff_type,
+                          typeof(linsolve),diff_type,
                           OrdinaryDiffEq._unwrap_val(standardtag),
                           OrdinaryDiffEq._unwrap_val(concrete_jac),
                           typeof(nlsolve),
                           typeof(new_jac_conv_bound),controller}(
-                          linsolve,nlsolve,precs,
+                          linsolve,nlsolve,
                           symplectic ? 1/2 : theta,
                           extrapolant,
                           new_jac_conv_bound,symplectic)
@@ -705,10 +701,9 @@ Defaults to solving the Ito problem, but ImplicitRKMil(interpretation=:Stratonov
 This method defaults to symplectic=false, but when true and theta=1/2 this is the implicit Midpoint method on the drift term and is symplectic in distribution.
 Handles diagonal and scalar noise. Uses a 1.5/2.0 heuristic for adaptive time stepping.
 """
-struct ImplicitRKMil{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller,interpretation} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct ImplicitRKMil{CS,AD,F,FDT,ST,CJ,N,T2,Controller,interpretation} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
   linsolve::F
   nlsolve::N
-  precs::P
   theta::T2
   extrapolant::Symbol
   new_jac_conv_bound::T2
@@ -716,19 +711,18 @@ struct ImplicitRKMil{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller,interpretation} <: Stoc
 end
 ImplicitRKMil(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                           standardtag = Val{true}(),concrete_jac = nothing,
-                          precs = OrdinaryDiffEq.DEFAULT_PRECS,
                           linsolve=nothing,nlsolve=NLNewton(),
                           extrapolant=:constant,
                           theta = 1,symplectic = false,
                           new_jac_conv_bound = 1e-3,
                           controller = :Predictive,interpretation=:Ito) =
                           ImplicitRKMil{chunk_size,autodiff,
-                          typeof(linsolve),typeof(precs),diff_type,
+                          typeof(linsolve),diff_type,
                           OrdinaryDiffEq._unwrap_val(standardtag),
                           OrdinaryDiffEq._unwrap_val(concrete_jac),
                           typeof(nlsolve),typeof(new_jac_conv_bound),
                           controller,interpretation}(
-                          linsolve,nlsolve,precs,
+                          linsolve,nlsolve,
                           symplectic ? 1/2 : theta,
                           extrapolant,
                           new_jac_conv_bound,symplectic)
@@ -740,10 +734,9 @@ This is a theta method which defaults to theta=1 or the Trapezoid method on the 
 This method defaults to symplectic=false, but when true and theta=1/2 this is the implicit Midpoint method on the drift term and is symplectic in distribution.
 Can handle all forms of noise, including non-diagonal, scalar, and colored noise. Uses a 1.0/1.5 heuristic for adaptive time stepping.
 """
-struct ISSEM{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct ISSEM{CS,AD,F,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
   linsolve::F
   nlsolve::N
-  precs::P
   theta::T2
   extrapolant::Symbol
   new_jac_conv_bound::T2
@@ -751,19 +744,18 @@ struct ISSEM{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdapt
 end
 ISSEM(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                        standardtag = Val{true}(),concrete_jac = nothing,
-                       precs = OrdinaryDiffEq.DEFAULT_PRECS,
                        linsolve=nothing,nlsolve=NLNewton(),
                        extrapolant=:constant,
                        theta = 1,symplectic=false,
                        new_jac_conv_bound = 1e-3,
                        controller = :Predictive) =
                        ISSEM{chunk_size,autodiff,
-                       typeof(linsolve),typeof(precs),diff_type,
+                       typeof(linsolve),diff_type,
                        OrdinaryDiffEq._unwrap_val(standardtag),
                        OrdinaryDiffEq._unwrap_val(concrete_jac),
                        typeof(nlsolve),
                        typeof(new_jac_conv_bound),controller}(
-                       linsolve,nlsolve,precs,
+                       linsolve,nlsolve,
                        symplectic ? 1/2 : theta,
                        extrapolant,
                        new_jac_conv_bound,symplectic)
@@ -775,10 +767,9 @@ This is a theta method which defaults to theta=1 or the Trapezoid method on the 
 This method defaults to symplectic=false, but when true and theta=1/2 this is the implicit Midpoint method on the drift term and is symplectic in distribution.
 Can handle all forms of noise, including non-diagonal,Q scalar, and colored noise. Uses a 1.0/1.5 heuristic for adaptive time stepping.
 """
-struct ISSEulerHeun{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct ISSEulerHeun{CS,AD,F,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
  linsolve::F
  nlsolve::N
- precs::P
  theta::T2
  extrapolant::Symbol
  new_jac_conv_bound::T2
@@ -786,18 +777,17 @@ struct ISSEulerHeun{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewt
 end
 ISSEulerHeun(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                       standardtag = Val{true}(),concrete_jac = nothing,
-                      precs = OrdinaryDiffEq.DEFAULT_PRECS,
                       linsolve=nothing,nlsolve=NLNewton(),
                       extrapolant=:constant,
                       theta = 1,symplectic=false,
                       new_jac_conv_bound = 1e-3,
                       controller = :Predictive) =
                       ISSEulerHeun{chunk_size,autodiff,
-                      typeof(linsolve),typeof(precs),diff_type,
+                      typeof(linsolve),diff_type,
                       OrdinaryDiffEq._unwrap_val(standardtag),
                       OrdinaryDiffEq._unwrap_val(concrete_jac),
                       typeof(nlsolve),typeof(new_jac_conv_bound),controller}(
-                      linsolve,nlsolve,precs,
+                      linsolve,nlsolve,
                       symplectic ? 1/2 : theta,
                       extrapolant,
                       new_jac_conv_bound,symplectic)
@@ -806,10 +796,9 @@ SKenCarp: Stiff Method
 Adaptive L-stable drift-implicit strong order 1.5 for additive Ito and Stratonovich SDEs with weak order 2.
 Can handle diagonal, non-diagonal and scalar additive noise.
 """
-struct SKenCarp{CS,AD,F,P,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
+struct SKenCarp{CS,AD,F,FDT,ST,CJ,N,T2,Controller} <: StochasticDiffEqNewtonAdaptiveAlgorithm{CS,AD,FDT,ST,CJ,Controller}
   linsolve::F
   nlsolve::N
-  precs::P
   smooth_est::Bool
   extrapolant::Symbol
   new_jac_conv_bound::T2
@@ -818,15 +807,14 @@ end
 
 SKenCarp(;chunk_size=0,autodiff=true,diff_type=Val{:central},
                    standardtag = Val{true}(),concrete_jac = nothing,
-                   precs = OrdinaryDiffEq.DEFAULT_PRECS,
                    linsolve=nothing,nlsolve=NLNewton(),
                    smooth_est=true,extrapolant=:min_correct,
                    new_jac_conv_bound = 1e-3,controller = :Predictive,
                    ode_error_est = true) =
- SKenCarp{chunk_size,autodiff,typeof(linsolve),typeof(precs),diff_type,
+ SKenCarp{chunk_size,autodiff,typeof(linsolve),diff_type,
         OrdinaryDiffEq._unwrap_val(standardtag),OrdinaryDiffEq._unwrap_val(concrete_jac),
         typeof(nlsolve),typeof(new_jac_conv_bound),controller}(
-        linsolve,nlsolve,precs,smooth_est,extrapolant,new_jac_conv_bound,
+        linsolve,nlsolve,smooth_est,extrapolant,new_jac_conv_bound,
         ode_error_est)
 
 


### PR DESCRIPTION
for comaptibility with https://github.com/SciML/OrdinaryDiffEq.jl/pull/2318. Unfortunately, I don't believe there is a way to correctly sequence these to prevent temporary breakage.