### PR TITLE
fix: remove type piracy of `alg_autodiff`

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -24,7 +24,7 @@ _alg_autodiff(::StochasticDiffEqNewtonAdaptiveAlgorithm{T, AD}) where {T, AD} = 
 _alg_autodiff(::StochasticDiffEqJumpNewtonAdaptiveAlgorithm{T, AD}) where {T, AD} = Val{AD}()
 _alg_autodiff(::StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm{T, AD}) where {T, AD} = Val{AD}()
 
-function OrdinaryDiffEqCore.alg_autodiff(alg)
+function OrdinaryDiffEqCore.alg_autodiff(alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm})
     ad = _alg_autodiff(alg)
     if ad == Val(false)
         return ADTypes.AutoFiniteDiff()


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
