### PR TITLE
Fix complex test, add _alg_autodiff method for Composite algs

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -23,6 +23,7 @@ _alg_autodiff(::StochasticDiffEqNewtonAlgorithm{T, AD}) where {T, AD} = Val{AD}(
 _alg_autodiff(::StochasticDiffEqNewtonAdaptiveAlgorithm{T, AD}) where {T, AD} = Val{AD}()
 _alg_autodiff(::StochasticDiffEqJumpNewtonAdaptiveAlgorithm{T, AD}) where {T, AD} = Val{AD}()
 _alg_autodiff(::StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm{T, AD}) where {T, AD} = Val{AD}()
+_alg_autodiff(alg::StochasticCompositeAlgorithm) = _alg_autodiff(alg.algs[end])
 
 function OrdinaryDiffEqCore.alg_autodiff(alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm})
     ad = _alg_autodiff(alg)

--- a/test/complex_tests.jl
+++ b/test/complex_tests.jl
@@ -39,6 +39,6 @@ end
 
   # currently broken
   for alg in implicit_autodiff
-    @test_throws ArgumentError solve(prob, alg)
+    @test_throws StochasticDiffEq.OrdinaryDiffEqDifferentiation.FirstAutodiffJacError solve(prob, alg)
   end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Will be needed to fix tests when https://github.com/SciML/OrdinaryDiffEq.jl/pull/2567 happens
