### PR TITLE
Add documentation for reusing noise realizations (fixes #425)

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -116,6 +116,108 @@ function g!(du, u, p, t)
 end
 ```
 
+### Using the Same Noise Realization Multiple Times
+
+For applications like computing snapshot attractors of random dynamical systems, you may need to solve the same SDE with different initial conditions but the same noise realization. This requires careful handling of the random number generator and noise process.
+
+#### Basic Approach
+
+```julia
+using StochasticDiffEq, Random, DiffEqNoiseProcess
+
+# Define your SDE
+function f!(du, u, p, t)
+    du[1] = -u[1] + p[1] * u[2]
+    du[2] = -u[2] - p[1] * u[1]
+end
+
+function g!(du, u, p, t)
+    du[1] = 0.1
+    du[2] = 0.1
+end
+
+# Create a specific RNG with a non-zero seed
+rng = Random.Xoshiro(1234)
+
+# Create a noise process that won't reseed
+noise = WienerProcess(0.0, 0.0, rng=rng, reseed=false)
+
+p = [2.0]
+tspan = (0.0, 1.0)
+
+# Solve with first initial condition
+u0_1 = [1.0, 0.0]
+prob1 = SDEProblem(f!, g!, u0_1, tspan, p, noise=noise)
+sol1 = solve(prob1, EM(), dt=0.01)
+
+# Reset the noise process to reuse the same realization
+# Create a new noise process with the same seed
+rng_reset = Random.Xoshiro(1234)  # Same seed as before
+noise = WienerProcess(0.0, 0.0, rng=rng_reset, reseed=false)
+
+# Solve with second initial condition using the same noise
+u0_2 = [0.0, 1.0]
+prob2 = SDEProblem(f!, g!, u0_2, tspan, p, noise=noise)
+sol2 = solve(prob2, EM(), dt=0.01)
+
+# Verify both solutions used the same noise
+@assert sol1.W.W == sol2.W.W  # Same noise realization
+```
+
+#### Solving Across Time Windows
+
+To solve an SDE across different time windows with the same noise continuation:
+
+```julia
+using StochasticDiffEq, Random, DiffEqNoiseProcess
+
+# Define SDE (same as above)
+function f!(du, u, p, t)
+    du[1] = -0.1 * u[1]
+    du[2] = -0.1 * u[2]
+end
+
+function g!(du, u, p, t)
+    du[1] = 0.2
+    du[2] = 0.2
+end
+
+# Setup with persistent RNG
+rng = Random.Xoshiro(5678)
+noise = WienerProcess(0.0, 0.0, rng=rng, reseed=false)
+
+u0 = [1.0, 1.0]
+dt = 0.01
+
+# First time window: t ∈ [0, 1]
+prob1 = SDEProblem(f!, g!, u0, (0.0, 1.0), noise=noise)
+sol1 = solve(prob1, EM(), dt=dt)
+
+# Second time window: t ∈ [1, 2] 
+# Continue from the end state of the first solution
+# The noise process automatically continues from where it left off
+u0_2 = sol1.u[end]  # Final state from first window
+prob2 = SDEProblem(f!, g!, u0_2, (1.0, 2.0), noise=noise)
+sol2 = solve(prob2, EM(), dt=dt)
+
+# Combine solutions if needed
+combined_t = [sol1.t[1:end-1]; sol2.t]  # Avoid duplicate at t=1
+combined_u = [sol1.u[1:end-1]; sol2.u]
+```
+
+#### Important Notes
+
+1. **Use non-zero seed**: Never use `seed=0` as this can cause issues with some RNGs
+2. **Set `reseed=false`**: This prevents the noise process from regenerating 
+3. **Consistent timestep**: Use the same `dt` across different solves for identical noise
+4. **Reset when needed**: Create a new noise process with the same seed to restart the same noise realization
+5. **Compatible solvers**: This approach works with fixed-timestep methods like `EM()`
+
+This technique is particularly valuable for:
+- Computing snapshot attractors in random dynamical systems
+- Studying sensitivity to initial conditions with fixed noise
+- Reproducible ensemble simulations with shared noise components
+
 ## Itô vs Stratonovich
 
 Specify interpretation when creating problems or choosing solvers:


### PR DESCRIPTION
## Summary
- Fixes #425 by adding comprehensive documentation for using the same noise realization multiple times
- Added new section "Using the Same Noise Realization Multiple Times" to `docs/src/usage.md`

## Problem
Users needed guidance on how to solve SDEs with the same noise realization across different initial conditions or time windows, which is important for computing snapshot attractors of random dynamical systems.

## Solution
Added detailed documentation covering:

### Basic Approach
- How to set up `WienerProcess` with `reseed=false` and specific RNG
- Using the same noise realization with different initial conditions
- Proper way to reset/recreate noise processes with the same seed

### Solving Across Time Windows  
- Continuing noise processes across multiple time intervals
- Combining solutions from different time windows
- Maintaining noise continuity between segments

### Important Notes
- Use non-zero seeds (never `seed=0`)
- Set `reseed=false` to prevent noise regeneration
- Use consistent timesteps for identical noise
- Compatible with fixed-timestep methods like `EM()`

## Test plan
- [x] Tested all code examples in the documentation
- [x] Verified noise realization consistency across different initial conditions
- [x] Confirmed noise continuation works across time windows
- [x] Examples successfully demonstrate the techniques described

## Applications
This documentation enables:
- Computing snapshot attractors in random dynamical systems
- Studying sensitivity to initial conditions with fixed noise
- Reproducible ensemble simulations with shared noise components

🤖 Generated with [Claude Code](https://claude.ai/code)