### PR TITLE
Fix deprecated AbstractDiffEqArray indexing patterns

### DIFF
--- a/test/cache_test.jl
+++ b/test/cache_test.jl
@@ -39,7 +39,7 @@ sol = solve(prob,SRIW1(),callback=callback)
 using Plots; pyplot()
 p1 = plot(sol,vars=(0,1),plotdensity=10000,title="Amount of X in Cell 1")
 scatter!(sol,denseplot=false)
-p2 = plot(sol.t,map((x)->length(x),sol[:]),lw=3,
+p2 = plot(sol.t,map((x)->length(x),sol.u),lw=3,
      ylabel="Number of Cells",xlabel="Time")
 plot(p1,p2,layout=(2,1),size=(600,1000))
 =#

--- a/test/events_test.jl
+++ b/test/events_test.jl
@@ -26,7 +26,7 @@ prob = SDEProblem(f,g,u0,tspan)
 
 sol = solve(prob,SRIW1(),callback=callback,adaptive=false,dt=3/4)
 
-@test minimum(sol[1,:]) > -1e-12 && minimum(sol[1,:]) < 1e-12
+@test minimum([u[1] for u in sol.u]) > -1e-12 && minimum([u[1] for u in sol.u]) < 1e-12
 
 sol = solve(prob,SRIW1(),callback=callback,save_everystep=false)
 t = sol.t[end÷2] # this is the callback time point

--- a/test/split_tests.jl
+++ b/test/split_tests.jl
@@ -12,7 +12,7 @@ sol = solve(prob,SplitEM(),dt=1/10,save_noise=true)
 prob = SDEProblem{false}(f,σ,1/2,(0.0,1.0),noise = NoiseWrapper(sol.W))
 sol2 = solve(prob,EM(),dt=1/10)
 
-@test sol[:] ≈ sol2[:]
+@test sol.u ≈ sol2.u
 
 u0 = rand(4)
 

--- a/test/tau_leaping.jl
+++ b/test/tau_leaping.jl
@@ -30,8 +30,8 @@ N = 40_000
 sol1 = solve(EnsembleProblem(jump_iipprob),SimpleTauLeaping();dt=1.0,trajectories = N)
 sol2 = solve(EnsembleProblem(jump_iipprob),TauLeaping();dt=1.0,adaptive=false,save_everystep=false,trajectories = N)
 
-mean1 = mean([sol1[i][end,end] for i in 1:N])
-mean2 = mean([sol2[i][end,end] for i in 1:N])
+mean1 = mean([sol1.u[i][end,end] for i in 1:N])
+mean2 = mean([sol2.u[i][end,end] for i in 1:N])
 @test mean1 ≈ mean2 rtol=1e-2
 
 f(du,u,p,t) = (du .= 0)
@@ -42,11 +42,11 @@ jumpdiff_iipprob = JumpProblem(iip_sdeprob,Direct(),rj)
 @time sol = solve(jumpdiff_iipprob,ImplicitEM();dt=1.0,adaptive=false)
 
 sol = solve(EnsembleProblem(jumpdiff_iipprob),EM();dt=1.0,trajectories = N)
-meanX = mean([sol[i][end,end] for i in 1:N])
+meanX = mean([sol.u[i][end,end] for i in 1:N])
 @test mean1 ≈ meanX rtol=1e-2
 
 sol = solve(EnsembleProblem(jumpdiff_iipprob),ImplicitEM();dt=1.0,trajectories = N)
-meanX = mean([sol[i][end,end] for i in 1:N])
+meanX = mean([sol.u[i][end,end] for i in 1:N])
 @test mean1 ≈ meanX rtol=1e-2
 
 iip_prob = DiscreteProblem([999,1,0],(0.0,250.0))
@@ -68,7 +68,7 @@ jump_prob = JumpProblem(prob,Direct(),rj)
 sol = solve(jump_prob,TauLeaping(),reltol=5e-2)
 
 sol2 = solve(EnsembleProblem(jump_prob),TauLeaping();dt=1.0,adaptive=false,save_everystep=false,trajectories = N)
-mean2 = mean([sol2[i][end,end] for i in 1:N])
+mean2 = mean([sol2.u[i][end,end] for i in 1:N])
 @test mean1 ≈ mean2 rtol=1e-2
 
 foop(u,p,t) = [0.0,0.0,0.0]
@@ -79,9 +79,9 @@ jumpdiff_prob = JumpProblem(oop_sdeprob,Direct(),rj)
 @time sol = solve(jumpdiff_prob,ImplicitEM();dt=1.0)
 
 sol = solve(EnsembleProblem(jumpdiff_prob),EM();dt=1.0,trajectories = 10_000)
-meanX = mean([sol[i][end,end] for i in 1:10_000])
+meanX = mean([sol.u[i][end,end] for i in 1:10_000])
 @test mean1 ≈ meanX rtol=1e-2
 
 sol = solve(EnsembleProblem(jumpdiff_prob),ImplicitEM();dt=1.0,trajectories = 1_000)
-meanX = mean([sol[i][end,end] for i in 1:1_000])
+meanX = mean([sol.u[i][end,end] for i in 1:1_000])
 @test mean1 ≈ meanX rtol=1e-1


### PR DESCRIPTION
This commit fixes several deprecation warnings related to AbstractDiffEqArray indexing by replacing deprecated patterns with the new recommended syntax:

- Replace `sol[:]` with `sol.u`
- Replace `sol[i]` with `sol.u[i]`
- Replace `sol[1,:]` with `[u[1] for u in sol.u]`

These changes eliminate deprecation warnings during test runs while maintaining the same functionality. The changes affect test files only and do not impact the core library functionality.

Files modified:
- test/cache_test.jl: Fixed `sol[:]` usage in plotting code
- test/tau_leaping.jl: Fixed multiple `sol[i][end,end]` indexing patterns
- test/split_tests.jl: Fixed `sol[:]` comparison
- test/events_test.jl: Fixed `sol[1,:]` indexing pattern

🤖 Generated with [Claude Code](https://claude.ai/code)
