### PR TITLE
test: fix usage of removed `generate_function` in tests

### DIFF
--- a/test/reversal_tests.jl
+++ b/test/reversal_tests.jl
@@ -126,7 +126,7 @@ end
     end
     sys = modelingtoolkitize(prob_forward)
     sys2 = stochastic_integral_transform(sys, -1 // 1)
-    fdrift = eval(generate_function(sys2)[i])
+    fdrift = eval(generate_rhs(sys2)[i])
     fdif = eval(generate_diffusion_function(sys2)[i])
 
     for solver in Ito_solver


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
